### PR TITLE
Handle TrackItem click event

### DIFF
--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -65,6 +65,7 @@ export default class JuxtaposeApplication extends React.Component {
             <div className="jux-time">
                 {formatDuration(this.state.time)} / {formatDuration(this.state.duration)}
             </div>
+            <MediaPopup />
             <div className="jux-timeline">
                 <Playhead ref={(c) => this._playhead = c}
                           callbackParent={this.onPlayheadUpdate.bind(this)} />

--- a/src/Track.jsx
+++ b/src/Track.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import ReactGridLayout from 'react-grid-layout';
 import TrackItem from './TrackItem.jsx';
+import GridItem from 'react-grid-layout';
 
 export default class Track extends React.Component {
-    onResize(event) {
-        console.log('resize');
+    constructor() {
+        super();
+        // FIXME: I can't figure out how to access the GridLayout
+        // or GridItem's dragging state from within the TrackItem,
+        // so I'm creating my own here.
+        this.state = {dragging: false};
     }
     /**
      * Scale percentage to track x co-ordinate (0 to 1000).
@@ -23,30 +28,35 @@ export default class Track extends React.Component {
                 const percent = (data.startTime / me.props.duration) * 100;
                 const xPos = me.percentToTrackCoords(percent);
                 const item = <TrackItem
-                               key={i}
-                               data={data}
-                               data-grid={{
-                                   x: xPos,
-                                   y: 0,
-                                   w: width,
-                                   h: 10
-                               }}
-                               duration={data.duration} />;
+                                 key={i}
+                                 dragging={me.state.dragging}
+                                 data={data}
+                                 data-grid={{
+                                     x: xPos,
+                                     y: 0,
+                                     w: width,
+                                     h: 10
+                                 }}
+                                 duration={data.duration} />;
                 items.push(item);
             }
         });
         return items;
     }
+    onDrag(e) {
+        this.setState({dragging: true});
+    }
     render() {
         const duration = this.props.duration;
         return <ReactGridLayout
-                   {...this.props}
                    width={600}
                    margin={[0,10]}
                    className="layout jux-track react-grid-layout"
                    cols={1000}
                    draggableCancel=".jux-stretch-handle"
+                   onDrag={this.onDrag.bind(this)}
                    onDragStop={this.props.onDragStop}
+                   maxRows={1}
                    rowHeight={1}>
                 {this.generateItems()}
             </ReactGridLayout>;

--- a/src/TrackItem.jsx
+++ b/src/TrackItem.jsx
@@ -30,6 +30,11 @@ export default class TrackItem extends React.Component {
     renderTxtThumb(data) {
         return <p className="aux-item-middle">{data.source}</p>;
     }
+    onClick(e) {
+        if (!this.props.dragging) {
+            console.log('click');
+        }
+    }
     render() {
         let style = {};
         if (this.props.duration) {
@@ -44,10 +49,11 @@ export default class TrackItem extends React.Component {
             c = this.renderTxtThumb(this.props.data);
         }
         return <div data={this.props.data}
+                    data-dragging={this.props.dragging}
                     className={this.props.className}
                     style={this.props.style}
+                    onClick={this.onClick.bind(this)}
                     onMouseDown={this.props.onMouseDown}
-                    onMouseUp={this.props.onMouseUp}
                     onTouchEnd={this.props.onTouchEnd}
                     onTouchStart={this.props.onTouchStart}>
             <div className="jux-stretch-handle jux-aux-item-left"></div>


### PR DESCRIPTION
Now I'm able to capture the grid item's click event, at least until the
item is dragged. What I really need to do is figure out how to connect
the GridItem's `dragging` state attribute to my `TrackItem`. I can't
figure out how to do this without altering the react-grid-layout
library, though. I hope I can figure this out.. I will start seeking out
some help.

Some related info:
https://github.com/STRML/react-grid-layout/issues/291#issuecomment-243253165