### PR TITLE
collection view basics - PMT #107908

### DIFF
--- a/css/juxtapose.css
+++ b/css/juxtapose.css
@@ -147,6 +147,28 @@ button.jux-play {
     padding: 10px;
 }
 
+.jux-collection-popup {
+    width: 240px;
+    height: 300px;
+}
+
+.jux-collection-scroll-area {
+    height: 200px;
+    overflow-y: scroll;
+}
+
+.jux-collection-item {
+    background-color: #fff;
+    padding-left: 5px;
+    padding-right: 5px;
+    margin-bottom: 4px;
+    margin-right: 5px;
+}
+
+.jux-collection-item img {
+    max-height: 80px;
+}
+
 /* TimelineRuler */
 .jux-timeline-ruler {
     height: 21px;

--- a/src/AuxTrack.jsx
+++ b/src/AuxTrack.jsx
@@ -1,6 +1,13 @@
+import React from 'react';
 import Track from './Track.jsx';
+import CollectionAdder from './CollectionAdder.jsx';
 
 export default class AuxTrack extends Track {
-    onAddTrackItemClick() {
+    renderItemAdder() {
+        return <CollectionAdder
+                   showing={this.state.adding}
+                   onCloseClick={this.closeItemAdder.bind(this)}
+                   collectionData={this.props.collectionData}
+                   onSubmit={this.onTrackItemAdd.bind(this)} />;
     }
 }

--- a/src/CollectionAdder.jsx
+++ b/src/CollectionAdder.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+export default class CollectionAdder extends React.Component {
+    constructor() {
+        super();
+        this.state = {
+            value: ''
+        }
+    }
+    onSubmit(e) {
+        e.preventDefault();
+        this.props.onSubmit(this.state.value, this.props.timestamp);
+    }
+    onTextChange(e) {
+        this.setState({value: e.target.value});
+    }
+    renderList() {
+        let list = [];
+        for (let i = 0; i < this.props.collectionData.length; i++) {
+            const el = this.props.collectionData[i];
+            list = list.concat(
+                <div key={i} className="jux-collection-item">
+                    <h5>{el.title}</h5>
+                    <img src={el.thumbnail} />
+                </div>
+            );
+        }
+        return list;
+    }
+    render() {
+        let contents = '';
+        if (this.props.showing) {
+            contents = <div className="jux-add-item-popup jux-collection-popup">
+                <button className="jux-popup-close"
+                        onClick={this.props.onCloseClick}
+                        title="Close">×</button>
+                <h2>Collection</h2>
+                <div className="jux-collection-scroll-area">
+                    {this.renderList()}
+                </div>
+            </div>;
+        }
+        return <div>{contents}</div>;
+    }
+}

--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactGridLayout from 'react-grid-layout';
 import _ from 'lodash';
 import {formatDuration} from './utils.js';
-import {auxTrackData, textTrackData} from './data.js';
+import {auxTrackData, textTrackData, collectionData} from './data.js';
 import AuxTrack from './AuxTrack.jsx';
 import AuxDisplay from './AuxDisplay.jsx';
 import TextTrack from './TextTrack.jsx';
@@ -18,10 +18,12 @@ export default class JuxtaposeApplication extends React.Component {
     constructor() {
         super();
         this.state = {
-            time: null,
-            duration: null,
             auxTrack: auxTrackData,
             textTrack: textTrackData,
+            collectionData: collectionData,
+
+            time: null,
+            duration: null,
 
             // The selected item that's managed in the TrackItemManager.
             activeItem: null
@@ -52,6 +54,8 @@ export default class JuxtaposeApplication extends React.Component {
                           callbackParent={this.onPlayheadUpdate.bind(this)} />
                 <AuxTrack duration={this.state.duration}
                           onDragStop={this.onAuxDragStop.bind(this)}
+                          onTrackItemAdd={this.onTrackItemAdd.bind(this)}
+                          collectionData={this.state.collectionData}
                           data={this.state.auxTrack} />
                 <TextTrack duration={this.state.duration}
                            onDragStop={this.onTextDragStop.bind(this)}

--- a/src/TextAnnotationAdder.jsx
+++ b/src/TextAnnotationAdder.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default class TrackItemAdder extends React.Component {
+export default class TextAnnotationAdder extends React.Component {
     constructor() {
         super();
         this.state = {

--- a/src/TextTrack.jsx
+++ b/src/TextTrack.jsx
@@ -1,4 +1,12 @@
+import React from 'react';
 import Track from './Track.jsx';
+import TextAnnotationAdder from './TextAnnotationAdder.jsx';
 
 export default class TextTrack extends Track {
+    renderItemAdder() {
+        return <TextAnnotationAdder
+                   showing={this.state.adding}
+                   onCloseClick={this.closeItemAdder.bind(this)}
+                   onSubmit={this.onTrackItemAdd.bind(this)} />;
+    }
 }

--- a/src/Track.jsx
+++ b/src/Track.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactGridLayout from 'react-grid-layout';
 import TrackItem from './TrackItem.jsx';
 import TrackItemAddColumn from './TrackItemAddColumn.jsx';
-import TrackItemAdder from './TrackItemAdder.jsx';
 import GridItem from 'react-grid-layout';
 
 
@@ -67,13 +66,13 @@ export default class Track extends React.Component {
     closeItemAdder() {
         this.setState({adding: false});
     }
+    renderItemAdder() {
+        return null;
+    }
     render() {
         const duration = this.props.duration;
         return <div className="jux-track">
-                    <TrackItemAdder
-                        showing={this.state.adding}
-                        onCloseClick={this.closeItemAdder.bind(this)}
-                        onSubmit={this.onTrackItemAdd.bind(this)} />
+                    {this.renderItemAdder()}
                     {this.generateSnapColumns()}
                     <ReactGridLayout
                         width={this.width}

--- a/src/data.js
+++ b/src/data.js
@@ -13,7 +13,6 @@ export const auxTrackData = [
         type: 'img',
         source: 'img/image.jpg'
     }
-
 ];
 
 export const textTrackData = [
@@ -30,5 +29,24 @@ export const textTrackData = [
         endTime: 55,
         type: 'txt',
         source: 'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+    }
+];
+
+export const collectionData = [
+    {
+        title: 'Item A',
+        thumbnail: 'img/image.jpg'
+    },
+    {
+        title: 'Item B',
+        thumbnail: 'img/image.jpg'
+    },
+    {
+        title: 'Item C',
+        thumbnail: 'img/image.jpg'
+    },
+    {
+        title: 'Item D',
+        thumbnail: 'img/image.jpg'
     }
 ];


### PR DESCRIPTION
I've separated out the logic for displaying the text popup vs. media popup.
I realize that this tool is probably not responsible for displaying the
media popup - we need to take advantage of the quick-edit and filtering
capabilities of the existing Mediathread collection browser. When I
started this branch, I was thinking it would be most
straightforward to expose some JSON from the back-end to build this
view, but I now realize there's too much functionality to rebuild, and
we want the familiar Mediathread browser here. So, after some
investigation it looks like we can pretty easily call external
JavaScript from within this React app. I still have to investigate how
the collection browser works on the Mediathread side.