### PR TITLE
Use ccnmtl/dev branch of react-grid-layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lodash": "~4.17.2",
     "react": "~15.4.0",
     "react-dom": "~15.4.0",
-    "react-grid-layout": "nikolas/react-grid-layout#add-prevent-collision",
+    "react-grid-layout": "ccnmtl/react-grid-layout#dev",
     "react-player": "^0.12.0",
     "react-vimeo": "~0.2.2",
     "react-youtube": "~7.2.0",


### PR DESCRIPTION
Because there's a few separate changes we need to make to the upstream
version of react-grid-layout, and since there will likely be more, I'm
connecting the sequence tool to the general `dev` branch of
ccnmtl/react-grid-layout.

https://github.com/STRML/react-grid-layout/pull/385
https://github.com/STRML/react-grid-layout/pull/437