### PR TITLE
Remove react-youtube and react-vimeo dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
     "react-dom": "~15.4.0",
     "react-grid-layout": "nikolas/react-grid-layout#add-prevent-collision",
     "react-player": "^0.12.0",
-    "react-vimeo": "~0.2.2",
-    "react-youtube": "~7.2.0",
     "webpack": "~1.13.1",
     "whatwg-fetch": "^2.0.0"
   },


### PR DESCRIPTION
These should have been removed in this PR:
https://github.com/ccnmtl/juxtapose/pull/97

We're now using react-player for both vimeo and youtube.