### PR TITLE
Xhr: remove empty body default

### DIFF
--- a/src/Xhr.js
+++ b/src/Xhr.js
@@ -25,8 +25,7 @@ export default class Xhr {
                 'Content-Type': 'application/json',
                 'X-CSRFToken': csrftoken
             },
-            credentials: 'same-origin',
-            body: {}
+            credentials: 'same-origin'
         };
     }
 


### PR DESCRIPTION
Fixes an error in my version of Firefox: "GET or HEAD requests cannot contain a body"