### PR TITLE
Always initialize super() with props

### DIFF
--- a/src/CollectionAdder.jsx
+++ b/src/CollectionAdder.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 export default class CollectionAdder extends React.Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
         this.state = {
             value: ''
         }

--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -18,8 +18,8 @@ import Xhr from './Xhr.js';
 
 
 export default class JuxtaposeApplication extends React.Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
         let self = this;
         this.state = {
             spineVideo: null,

--- a/src/MediaDisplay.jsx
+++ b/src/MediaDisplay.jsx
@@ -16,8 +16,8 @@ export function getCurrentItem(data, currentTime) {
 
 
 export default class MediaDisplay extends React.Component {
-    constructor() {
-        super()
+    constructor(props) {
+        super(props)
         this.className = 'jux-media-video';
     }
     renderVideo(data) {

--- a/src/MediaTrack.jsx
+++ b/src/MediaTrack.jsx
@@ -3,8 +3,8 @@ import Track from './Track.jsx';
 import {createCollectionWidget} from './mediathreadCollection.js';
 
 export default class MediaTrack extends Track {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
         this.type = 'media';
     }
     onAddTrackElementClick() {

--- a/src/SpineVideo.jsx
+++ b/src/SpineVideo.jsx
@@ -3,8 +3,8 @@ import ReactPlayer from 'react-player'
 import {createCollectionWidget} from './mediathreadCollection.js';
 
 export default class SpineVideo extends React.Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
         this.id = 'jux-spine-video';
     }
     render() {

--- a/src/TextAnnotationAdder.jsx
+++ b/src/TextAnnotationAdder.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 export default class TextAnnotationAdder extends React.Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
         this.state = {
             value: ''
         }

--- a/src/TextTrack.jsx
+++ b/src/TextTrack.jsx
@@ -3,8 +3,8 @@ import Track from './Track.jsx';
 import TextAnnotationAdder from './TextAnnotationAdder.jsx';
 
 export default class TextTrack extends Track {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
         this.type = 'txt';
     }
     renderItemAdder() {

--- a/src/Track.jsx
+++ b/src/Track.jsx
@@ -26,8 +26,8 @@ function isActive(activeItem, type, i) {
 
 
 export default class Track extends React.Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
         this.state = {
             adding: false
         };

--- a/src/TrackElement.jsx
+++ b/src/TrackElement.jsx
@@ -3,8 +3,8 @@ import VidItemThumb from './VidItemThumb.jsx';
 import {ellipsis} from './utils.js';
 
 export default class TrackElement extends React.Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
         this.state = {
             vimeoThumbnailUrl: null
         }


### PR DESCRIPTION
From the React docs:

> When implementing the constructor for a React.Component subclass, you
> should call super(props) before any other statement. Otherwise,
> this.props will be undefined in the constructor, which can lead to bugs.

https://facebook.github.io/react/docs/react-component.html#constructor