### PR TITLE
Turn off unnecessary grid options

### DIFF
--- a/src/Track.jsx
+++ b/src/Track.jsx
@@ -102,6 +102,8 @@ export default class Track extends React.Component {
                         onClick={this.onClick}
                         maxRows={1}
                         rowHeight={1}
+                        autoSize={false}
+                        isResizable={false}
                         preventCollision={true}>
                         {this.generateItems(this.props.data)}
                     </ReactGridLayout>


### PR DESCRIPTION
Turning off isResizable removes some unnecessary mixins, and turning off
autoSize prevents the grid from growing in height when one element is
placed over another, which will never happen anyways.