### PR TITLE
MediaTrackElement interaction - place element in clicked location

### DIFF
--- a/src/MediaTrack.jsx
+++ b/src/MediaTrack.jsx
@@ -7,7 +7,11 @@ export default class MediaTrack extends Track {
         super(props);
         this.type = 'media';
     }
-    onAddTrackElementClick() {
-        createCollectionWidget('all');
+    onAddTrackElementClick(e, absoluteTimecode) {
+        let caller = {
+            'type': 'track',
+            'timecode': absoluteTimecode
+        }
+        createCollectionWidget('all', caller);
     }
 }

--- a/src/SpineVideo.jsx
+++ b/src/SpineVideo.jsx
@@ -60,6 +60,6 @@ export default class SpineVideo extends React.Component {
     }
     // TODO: handle playback finish event
     onClick() {
-        createCollectionWidget('video');
+        createCollectionWidget('video', 'spine');
     }
 }

--- a/src/Track.jsx
+++ b/src/Track.jsx
@@ -62,17 +62,21 @@ export default class Track extends React.Component {
     }
     generateSnapColumns() {
         let columns = [];
-        for (let i = 0; i < (this.width / 10); i++) {
+        let n = this.width / 10;
+        let duration = this.props.duration / n;
+        for (let i = 0; i < n; i++) {
+            let timecode = duration * i;
             columns.push(
                 <TrackElementAddColumn
                     key={i}
                     idx={i}
+                    absoluteTimecode={timecode}
                     callbackParent={this.onAddTrackElementClick.bind(this)} />
             );
         }
         return columns;
     }
-    onAddTrackElementClick() {
+    onAddTrackElementClick(e, absoluteTimecode) {
         this.setState({adding: true});
     }
     onTrackElementAdd(value, timestamp) {

--- a/src/TrackElementAddColumn.jsx
+++ b/src/TrackElementAddColumn.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default class TrackElementAddColumn extends React.Component {
     onClick(e) {
-        this.props.callbackParent(e);
+        this.props.callbackParent(e, this.props.absoluteTimecode);
     }
     render() {
         return <div className="jux-snap-column"

--- a/src/mediathreadCollection.js
+++ b/src/mediathreadCollection.js
@@ -7,9 +7,10 @@
  * of React here.
  */
 
-export function createCollectionWidget(mediaType) {
+export function createCollectionWidget(mediaType, caller) {
     jQuery(window).trigger('collection.open', [{
         'media_type': mediaType,
-	'disable': mediaType === 'all' ? [] : ['media_type']
+        'disable': mediaType === 'all' ? [] : ['media_type'],
+        'caller': caller
     }]);
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -59,12 +59,34 @@ export function extractAssetData(s) {
 }
 
 /**
- * extractVideoData
+ * extractAnnotation
  *
- * Given a video source object in Mediathread's asset api format,
+ * Given a source object in Mediathread's asset api format,
+ * return a annotation properties
+ */
+export function extractAnnotation(assetCtx, annotationId) {
+    for (var i = 0; i < assetCtx.annotations.length && annotationId; i++) {
+        let annotation = assetCtx.annotations[i];
+        if (annotation.id === annotationId) {
+            if (!annotation.is_global_annotation) {
+                let duration = annotation.range2 - annotation.range1;
+                return {
+                    duration: Math.min(30, duration),
+                    range1: annotation.range1
+                };
+            }
+        }
+    }
+    return {duration: 30, range1: 0};
+}
+
+/**
+ * extractSource
+ *
+ * Given a source object in Mediathread's asset api format,
  * return a juxtapose media object.
  */
-export function extractVideoData(o) {
+export function extractSource(o) {
     if (o.youtube && o.youtube.url) {
         return {
             url: getYouTubeID(o.youtube.url),
@@ -81,8 +103,14 @@ export function extractVideoData(o) {
             url: o.mp4_pseudo.url
         };
     }
+    if (o.mp4_audio && o.mp4_audio.url) {
+        return {
+            url: o.mp4_audio.url
+        };
+    }
     return null;
 }
+
 
 /**
  * Given a number of seconds as a float, return an array


### PR DESCRIPTION
* Initialize the SnapColumns with the approximate timecode based on the selected spine video's duration.
* When a user clicks the media track and selects a Mediathread object, use the calculated timecode to place the element in the correct location in the track.
* Use the selected Mediathread object's duration to specify the width of the track element.