### PR TITLE
Only update video players on mouseUp - PMT #109139

### DIFF
--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -149,6 +149,7 @@ export default class JuxtaposeApplication extends React.Component {
                 <TimelineRuler duration={this.state.duration} />
                 <Playhead currentTime={this.state.time}
                           duration={this.state.duration}
+                          onMouseUp={this.onPlayheadMouseUp.bind(this)}
                           onChange={this.onPlayheadTimeChange.bind(this)} />
                 <MediaTrack
                     duration={this.state.duration}
@@ -313,6 +314,10 @@ export default class JuxtaposeApplication extends React.Component {
         const percentDone = e.target.value / 1000;
         const newTime = this.state.duration * percentDone;
         this.setState({time: newTime});
+    }
+    onPlayheadMouseUp(e) {
+        const percentDone = e.target.value / 1000;
+        const newTime = this.state.duration * percentDone;
         this._spineVid.updateVidPosition(percentDone);
         this._mediaVid.updateVidPosition(newTime);
     }

--- a/src/Playhead.jsx
+++ b/src/Playhead.jsx
@@ -21,6 +21,7 @@ export default class Playhead extends React.Component {
             <input type="range" min="0" max="1000"
                    ref={(ref) => this.el = ref}
                    onChange={this.props.onChange}
+                   onMouseUp={this.props.onMouseUp}
                    value={currentPos * 1000} />
         </div>;
     }


### PR DESCRIPTION
This improves the behavior a bit by not constantly seeking as you drag
the playhead. I looked at this code here to see how the author of
react-player uses this library:

* https://github.com/CookPete/react-player/blob/master/src/demo/App.js

Which runs this player:

* http://rplayr.com/user/evilnight/m/truemusic

Note that the problem of the playhead "jumping" to the wrong position
remains, but now it will be much easier to debug that bug.