### PR TITLE
Update dirty state after adding a media element

### DIFF
--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -93,6 +93,8 @@ export default class JuxtaposeApplication extends React.Component {
                            mediaTrack: newTrack
                        });
                    }
+                   jQuery(window).trigger('sequenceassignment.set_dirty',
+                                          {'dirty': true});
                });
         });
 


### PR DESCRIPTION
Whether the user added the primary video or a track element, the sequence will now be dirty.