### PR TITLE
Fix playhead jumping bug - PMT #109139

### DIFF
--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -171,10 +171,11 @@ export default class JuxtaposeApplication extends React.Component {
                     onVideoEnd={this.onSpineVideoEnd.bind(this)}
                     playing={this.state.isPlaying}
                     onProgress={this.onSpineProgress.bind(this)} />
-                <MediaDisplay time={this.state.time}
-                            data={this.state.mediaTrack}
-                            isPlaying={this.state.isPlaying}
-                            ref={(c) => this._mediaVid = c} />
+                <MediaDisplay
+                    time={this.state.time}
+                    data={this.state.mediaTrack}
+                    playing={this.state.isPlaying}
+                    ref={(c) => this._mediaVid = c} />
             </div>
             <TextDisplay time={this.state.time}
                          duration={this.state.duration}
@@ -302,14 +303,6 @@ export default class JuxtaposeApplication extends React.Component {
     onPlayClick(e) {
         const newState = !this.state.isPlaying;
         this.setState({isPlaying: newState})
-
-        // TODO: this should be more declarative, handled by the
-        // video components.
-        if (newState) {
-            this._mediaVid.play();
-        } else {
-            this._mediaVid.pause();
-        }
     }
     /**
      * Remove the active track item.
@@ -343,11 +336,9 @@ export default class JuxtaposeApplication extends React.Component {
         const newTime = this.state.duration * percentDone;
         this.setState({time: newTime});
     }
-    onPlayheadMouseUp(e) {
-        const percentDone = e.target.value / 1000;
-        const newTime = this.state.duration * percentDone;
-        this._spineVid.updateVidPosition(percentDone);
-        this._mediaVid.updateVidPosition(newTime);
+    onPlayheadMouseUp() {
+        const percentage = this.state.time / this.state.duration;
+        this._spineVid.updateVidPosition(percentage);
     }
     onSpineVideoEnd() {
         this.setState({isPlaying: false});
@@ -360,9 +351,8 @@ export default class JuxtaposeApplication extends React.Component {
     }
     onSpineProgress(state) {
         if (typeof state.played !== 'undefined') {
-            this.setState({
-                time: state.played * 100
-            });
+            const seconds = this.state.duration * state.played;
+            this.setState({time: seconds});
         }
     }
     onSaveClick() {

--- a/src/SpineVideo.jsx
+++ b/src/SpineVideo.jsx
@@ -53,8 +53,8 @@ export default class SpineVideo extends React.Component {
                 {editButton}
         </div>;
     }
-    updateVidPosition(percent) {
-        this.player.seekTo(percent);
+    updateVidPosition(fraction) {
+        this.player.seekTo(fraction);
     }
     onLoadedMetadata(e) {
         const vid = e.target;


### PR DESCRIPTION
There was some confusion between our code and react-player, since
react-player uses percentage as the timecode, and we're using the
absolute measure of seconds.

I'll fix up the secondary media display in a future PR.