### PR TITLE
Media saving fix - PMT #108991

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -160,7 +160,7 @@ export function prepareMediaData(array) {
     let a = _.cloneDeep(array);
     for (let e of a) {
         // We only need the Mediathread ID here.
-        e.media = e.id;
+        e.media = e.id || e.media;
         delete e.host;
         delete e.source;
     }


### PR DESCRIPTION
Add more flexibility when preparing media data for the API. This fixes a bug where an image element caused a save error when I changed its position.