### PR TITLE
Instructions - secondary materials and custom

### DIFF
--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -170,12 +170,16 @@ export default class JuxtaposeApplication extends React.Component {
                     onDuration={this.onSpineDuration.bind(this)}
                     onVideoEnd={this.onSpineVideoEnd.bind(this)}
                     playing={this.state.isPlaying}
-                    onProgress={this.onSpineProgress.bind(this)} />
+                    onProgress={this.onSpineProgress.bind(this)}
+                    instructions={this.props.primaryInstructions}
+                />
                 <MediaDisplay
                     time={this.state.time}
                     data={this.state.mediaTrack}
                     playing={this.state.isPlaying}
-                    ref={(c) => this._mediaVid = c} />
+                    ref={(c) => this._mediaVid = c}
+                    instructions={this.props.secondaryInstructions}
+                />
             </div>
             <TextDisplay time={this.state.time}
                          duration={this.state.duration}

--- a/src/MediaDisplay.jsx
+++ b/src/MediaDisplay.jsx
@@ -55,6 +55,23 @@ export default class MediaDisplay extends React.Component {
         return '';
     }
     render() {
+        if (this.props.data.length < 1) {
+            return <div className="jux-media-display">
+              <div className="help-text">
+                  <h1>Place secondary elements</h1>
+                  <p className="instructions">
+                      Click the tracks below to add<br />
+                      <span className="media-track-icon"></span>
+                      media and
+                      <span className="text-track-icon"></span>
+                      text elements
+                      <br /><br />
+                      {this.props.instructions}
+                  </p>
+              </div>
+            </div>;
+        }
+
         let c = this.nowDisplay(this.props.data, this.props.time);
         return <div className="jux-media-display">{c}</div>;
     }

--- a/src/SpineVideo.jsx
+++ b/src/SpineVideo.jsx
@@ -13,6 +13,7 @@ export default class SpineVideo extends React.Component {
               <div className="help-text">
               <button className="add-spine" onClick={this.onClick}></button>
               <h1>Add a primary video</h1>
+              <p className="instructions">{this.props.instructions}</p>
               </div>
             </div>;
         }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,6 +4,10 @@ import JuxtaposeApplication from './JuxtaposeApplication.jsx';
 
 
 ReactDOM.render(
-    <JuxtaposeApplication readOnly={(view && view.submitted) || false} />,
+    <JuxtaposeApplication
+        readOnly={(view && view.submitted) || false}
+        primaryInstructions={view && view.primaryInstructions || ''}
+        secondaryInstructions={view && view.secondaryInstructions || ''}
+    />,
     document.getElementById('jux-container')
 );


### PR DESCRIPTION
Add media display instructions when secondary materials are empty
Pick up custom instructions from the containing view and display