### PR TITLE
Makefile updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@ JS_SENTINAL ?= $(NODE_MODULES)/sentinal
 $(JS_SENTINAL): package.json
 	rm -rf $(NODE_MODULES)
 	npm install
-	cd $(NODE_MODULES)/react-grid-layout && npm install
-	cd ../..
+	cd $(NODE_MODULES)/react-grid-layout && npm install && make build-js
 	touch $(JS_SENTINAL)
 
 build: $(JS_SENTINAL) build/bundle.js


### PR DESCRIPTION
* Remove the `cd ../..` step. This is unnecessary as each Makefile step is executed in its own shell.
* Add the `make build-js` step to the react-grid-layout build. This fixes a bug I encountered with some recent changes the author made to his version of react-grid-layout, and still works with the version we're currently using.