### PR TITLE
Use bootstrap modal for entering text annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "js-cookie": "^2.1.3",
     "lodash": "~4.17.2",
     "react": "~15.4.0",
+    "react-bootstrap": "~0.30.7",
     "react-dom": "~15.4.0",
     "react-grid-layout": "ccnmtl/react-grid-layout#dev",
     "react-player": "^0.13.0",

--- a/src/TextAnnotationAdder.jsx
+++ b/src/TextAnnotationAdder.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Modal} from 'react-bootstrap';
 
 export default class TextAnnotationAdder extends React.Component {
     constructor(props) {
@@ -15,25 +16,27 @@ export default class TextAnnotationAdder extends React.Component {
     onTextChange(e) {
         this.setState({value: e.target.value});
     }
+    close() {
+        this.props.onCloseClick();
+    }
     render() {
-        let contents = '';
-        if (this.props.showing) {
-            contents = <div className="jux-add-item-popup">
-                <button className="jux-popup-close"
-                        onClick={this.props.onCloseClick}
-                        title="Close">×</button>
-                <h2>Add item</h2>
-                <form onSubmit={this.onSubmit.bind(this)}>
-                    <textarea className="form-control"
-                              maxLength={140}
-                              onChange={this.onTextChange.bind(this)}
-                              value={this.state.value} />
-                    <div>
-                        <button className="btn btn-primary right" type="submit">Submit</button>
-                    </div>
-                </form>
-            </div>;
-        }
-        return <div>{contents}</div>;
+        return <Modal show={this.props.showing} onHide={this.close.bind(this)}>
+    <Modal.Header closeButton>
+        <Modal.Title>Add text annotation</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+        <form onSubmit={this.onSubmit.bind(this)}>
+            <textarea className="form-control"
+                      maxLength={140}
+                      onChange={this.onTextChange.bind(this)}
+                      value={this.state.value} />
+            <br />
+            <button className="btn btn-primary right" type="submit">
+                Submit
+            </button>
+        </form>
+        <div className="clearfix"></div>
+    </Modal.Body>
+        </Modal>;
     }
 }


### PR DESCRIPTION
To mirror the CollectionWidget UI.

![2016-12-22-131035_673x226_scrot](https://cloud.githubusercontent.com/assets/59292/21435497/3cb85422-c848-11e6-8249-a5fcd254f3b1.png)
