### PR TITLE
Save/load annotations

### DIFF
--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -54,16 +54,16 @@ describe('collisionPresent', () => {
 
 describe('extractAssetData', () => {
     it('handles bogus input', () => {
-        expect(extractAssetData('').id).toBe(null);
+        expect(extractAssetData('').assetId).toBe(null);
         expect(extractAssetData('').annotationId).toBe(null);
-        expect(extractAssetData(null).id).toBe(null);
+        expect(extractAssetData(null).assetId).toBe(null);
         expect(extractAssetData(null).annotationId).toBe(null);
     });
     it('extracts the url correctly', () => {
-        expect(extractAssetData('/asset/124567/').id).toBe(124567);
+        expect(extractAssetData('/asset/124567/').assetId).toBe(124567);
         expect(extractAssetData('/asset/124567/').annotationId).toBe(null);
         expect(extractAssetData(
-            '/asset/124567/annotations/15161/').id).toBe(124567);
+            '/asset/124567/annotations/15161/').assetId).toBe(124567);
         expect(extractAssetData(
             '/asset/124567/annotations/15161/').annotationId).toBe(15161);
     });

--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -133,12 +133,13 @@ export default class JuxtaposeApplication extends React.Component {
                    textTrack: loadTextData(sequenceAsset.text_elements)
                });
 
-               let promises = [];
-               promises.push(
-                   xhr.getAsset(sequenceAsset.spine_asset)
+               return xhr
+                   .getAsset(sequenceAsset.spine_asset)
                    .then(function(json) {
                        const ctx = parseAsset(
-                           json, sequenceAsset.spine_asset, sequenceAsset.spine);
+                           json,
+                           sequenceAsset.spine_asset,
+                           sequenceAsset.spine);
 
                        self.setState({
                            spineVideo: {
@@ -152,8 +153,10 @@ export default class JuxtaposeApplication extends React.Component {
                            isPlaying: false,
                            time: 0
                        });
-                   }));
-              return Promise.all(promises);
+                   })
+                   .catch(function(error) {
+                       console.error('Sequence loading error:', error);
+                   });
            }).then(function() {
                jQuery(window).trigger('sequenceassignment.set_submittable', {
                    submittable: self.isBaselineWorkCompleted()

--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactGridLayout from 'react-grid-layout';
 import _ from 'lodash';
 import {
-    collisionPresent, extractAssetData, extractSource, extractAnnotation,
+    collisionPresent, extractAssetData, parseAsset,
     formatTimecode, loadMediaData, loadTextData
 } from './utils.js';
 import MediaTrack from './MediaTrack.jsx';
@@ -42,54 +42,40 @@ export default class JuxtaposeApplication extends React.Component {
             // on what the user is doing.
             const assetData = extractAssetData(e.detail.annotation);
             const xhr = new Xhr();
-            xhr.getAsset(assetData.id)
-               .then(function(asset) {
-                   const assetCtx = asset.assets[assetData.id];
-                   const source = extractSource(assetCtx.sources);
-                   const annotation = extractAnnotation(assetCtx, assetData.annotationId);
+            xhr.getAsset(assetData.assetId)
+               .then(function(json) {
+                   const ctx = parseAsset(
+                       json, assetData.assetId, assetData.annotationId);
                    
                    if (e.detail.caller.type === 'spine') {
                        // Set the spine video
                        self.setState({
                            spineVideo: {
-                               url: source.url,
-                               host: source.host,
-                               id: assetData.id,
+                               url: ctx.url,
+                               host: ctx.host,
+                               assetId: assetData.assetId,
                                annotationId: assetData.annotationId,
-                               annotationStartTime: annotation.startTime,
-                               annotationDuration: annotation.duration
+                               annotationStartTime: ctx.startTime,
+                               annotationDuration: ctx.duration
                            },
                            isPlaying: false,
                            time: 0
                        });
                    } else {
                        let newTrack = self.state.mediaTrack.slice(0);
-                       if (assetCtx.primary_type === 'image') {
-                           newTrack.push({
-                               key: newTrack.length,
-                               start_time: e.detail.caller.timecode,
-                               end_time: e.detail.caller.timecode + annotation.duration,
-                               type: 'img',
-                               host: source.host,
-                               source: source.url,
-                               id: assetData.id,
-                               annotationId: assetData.annotationId,
-                               annotationData: annotation.annotationData
-                           });
-                       } else {
-                           newTrack.push({
-                               key: newTrack.length,
-                               start_time: e.detail.caller.timecode,
-                               end_time: e.detail.caller.timecode + annotation.duration,
-                               annotationStartTime: annotation.startTime,
-                               annotationDuration: annotation.duration,
-                               type: 'vid',
-                               host: source.host,
-                               source: source.url,
-                               id: assetData.id,
-                               annotationId: assetData.annotationId
-                           });
-                       }
+                       newTrack.push({
+                           key: newTrack.length,
+                           start_time: e.detail.caller.timecode,
+                           end_time: e.detail.caller.timecode + ctx.duration,
+                           type: ctx.type,
+                           host: ctx.host,
+                           source: ctx.url,
+                           assetId: assetData.assetId,
+                           annotationId: assetData.annotationId,
+                           annotationData: ctx.data,
+                           annotationStartTime: ctx.startTime,
+                           annotationDuration: ctx.duration
+                       });
 
                        self.setState({
                            mediaTrack: newTrack
@@ -126,45 +112,46 @@ export default class JuxtaposeApplication extends React.Component {
         const xhr = new Xhr();
         xhr.getSequenceAsset(currentProject)
            .then(function(sequenceAsset) {
-               if (!sequenceAsset) {
+               if (!sequenceAsset || !sequenceAsset.spine) {
                    return;
                }
 
+               xhr.getAsset(sequenceAsset.spine_asset)
+                   .then(function(json) {
+                       const ctx = parseAsset(
+                           json, sequenceAsset.spine_asset, sequenceAsset.spine);
+
+                       self.setState({
+                           spineVideo: {
+                               url: ctx.url,
+                               host: ctx.host,
+                               assetId: sequenceAsset.spine_asset,
+                               annotationId: sequenceAsset.spine,
+                               annotationStartTime: ctx.annotationStartTime,
+                               annotationDuration: ctx.annotationEndTime
+                           },
+                           isPlaying: false,
+                           time: 0
+                       });
+               });
+
                // Fetch each media element's actual media from Mediathread.
                sequenceAsset.media_elements.forEach(function(e) {
-                   xhr.getAsset(e.media).then(function(asset) {
-                       const sources = asset.assets[e.media].sources;
-                       const source = extractSource(sources);
-                       e.source = source.url;
-                       if (asset.assets[e.media].primary_type === 'image') {
-                           e.type = 'img';
-                       } else {
-                           e.type = 'vid';
-                       }
+                   xhr.getAsset(e.media_asset).then(function(json) {
+                       const ctx = parseAsset(json, e.media_asset, e.media);
+                       e.host = ctx.host;
+                       e.source = ctx.url;
+                       e.type = ctx.type;
+                       e.annotationStartTime = ctx.startTime;
+                       e.annotationDuration = ctx.duration;
+                       e.annotationData = ctx.data;
                    });
                });
                self.setState({
                    mediaTrack: loadMediaData(sequenceAsset.media_elements),
                    textTrack: loadTextData(sequenceAsset.text_elements)
                });
-               if (sequenceAsset.spine) {
-                   xhr.getAsset(sequenceAsset.spine)
-                      .then(function(spine) {
-                          const sources = spine.assets[sequenceAsset.spine]
-                                              .sources;
-                          const vid = extractSource(sources);
-                          self.setState({
-                              spineVideo: {
-                                  url: vid.url,
-                                  host: vid.host,
-                                  id: sequenceAsset.spine
-                              },
-                              isPlaying: false,
-                              time: 0
-                          });
-                      });
-               }
-           });
+       });
     }
     render() {
         const activeItem = this.getItem(this.state.activeItem);
@@ -408,7 +395,7 @@ export default class JuxtaposeApplication extends React.Component {
     onSaveClick() {
         const xhr = new Xhr();
         xhr.createOrUpdateSequenceAsset(
-            this.state.spineVideo.id,
+            this.state.spineVideo.annotationId,
             window.MediaThread.current_course,
             window.MediaThread.current_project,
             this.state.mediaTrack,

--- a/src/SpineVideo.jsx
+++ b/src/SpineVideo.jsx
@@ -103,7 +103,7 @@ export default class SpineVideo extends React.Component {
         let caller = {
             'type': 'spine',
         };
-        editAnnotationWidget(this.props.spineVideo.id,
+        editAnnotationWidget(this.props.spineVideo.assetId,
                              this.props.spineVideo.annotationId,
                              caller);
     }

--- a/src/Xhr.js
+++ b/src/Xhr.js
@@ -70,9 +70,9 @@ export default class Xhr {
                 return null;
             });
     }
-    createOrUpdateSequenceAsset(spineVidId, courseId, projectId,
+    createOrUpdateSequenceAsset(annotationId, courseId, projectId,
                                 mediaTrack, textTrack) {
-        if (!spineVidId || !courseId || !projectId ||
+        if (!annotationId || !courseId || !projectId ||
             !mediaTrack || !textTrack
            ) {
             throw 'createOrUpdateSequenceAsset: missing parameter';
@@ -87,14 +87,14 @@ export default class Xhr {
                     const sequenceAssetId = json[0].sequence_asset.id;
                     return self.updateSequenceAsset(
                         sequenceAssetId,
-                        spineVidId,
+                        annotationId,
                         courseId,
                         projectId,
                         mediaTrack,
                         textTrack);
                 } else {
                     return self.createSequenceAsset(
-                        spineVidId,
+                        annotationId,
                         courseId,
                         projectId,
                         mediaTrack,
@@ -102,9 +102,9 @@ export default class Xhr {
                 }
             });
     }
-    createSequenceAsset(spineVidId, courseId, projectId,
+    createSequenceAsset(annotationId, courseId, projectId,
                         mediaTrack, textTrack) {
-        if (!spineVidId || !courseId || !projectId ||
+        if (!annotationId || !courseId || !projectId ||
             !mediaTrack || !textTrack
            ) {
             throw 'createSequenceAsset: missing parameter';
@@ -112,7 +112,7 @@ export default class Xhr {
 
         this.xhrOpts.method = 'post';
         this.xhrOpts.body = JSON.stringify({
-            spine: spineVidId,
+            spine: annotationId,
             course: courseId,
             project: projectId,
             media_elements: prepareMediaData(mediaTrack),
@@ -120,9 +120,9 @@ export default class Xhr {
         });
         return fetch(this.sequenceAssetsUrl(), this.xhrOpts);
     }
-    updateSequenceAsset(sequenceAssetId, spineVidId, courseId, projectId,
+    updateSequenceAsset(sequenceAssetId, annotationId, courseId, projectId,
                         mediaTrack, textTrack) {
-        if (!sequenceAssetId || !spineVidId || !courseId || !projectId ||
+        if (!sequenceAssetId || !annotationId || !courseId || !projectId ||
             !mediaTrack || !textTrack
            ) {
             throw 'updateSequenceAsset: missing parameter';
@@ -131,7 +131,7 @@ export default class Xhr {
         this.xhrOpts.method = 'put';
         this.xhrOpts.body = JSON.stringify({
             id: sequenceAssetId,
-            spine: spineVidId,
+            spine: annotationId,
             course: courseId,
             project: projectId,
             media_elements: prepareMediaData(mediaTrack),

--- a/src/utils.js
+++ b/src/utils.js
@@ -202,7 +202,7 @@ export function pad2(number) {
 export function prepareMediaData(array) {
     let a = _.cloneDeep(array);
     for (let e of a) {
-        e.media = e.annotationId;
+        e.media = e.annotationId || e.media;
         delete e.host;
         delete e.source;
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -78,7 +78,7 @@ export function extractAssetData(s) {
         }
     }
     return {
-        'id': id,
+        'assetId': id,
         'annotationId': annotationId
     };
 }
@@ -144,6 +144,24 @@ export function extractSource(o) {
     return null;
 }
 
+/**
+ * parseAsset
+ * 
+ */
+export function parseAsset(json, assetId, annotationId) {
+    const assetCtx = json.assets[assetId];
+    const source = extractSource(assetCtx.sources);
+    const annotation = extractAnnotation(assetCtx, annotationId);
+    const type = assetCtx.primary_type === 'image' ? 'img' : 'vid';
+    return {
+        url: source.url,
+        host: source.host,
+        type: type,
+        startTime: annotation.range1,
+        duration: annotation.duration,
+        data: annotation.annotationData
+    };
+}
 
 /**
  * Given a number of seconds as a float, return an array
@@ -184,8 +202,7 @@ export function pad2(number) {
 export function prepareMediaData(array) {
     let a = _.cloneDeep(array);
     for (let e of a) {
-        // We only need the Mediathread ID here.
-        e.media = e.id || e.media;
+        e.media = e.annotationId;
         delete e.host;
         delete e.source;
     }


### PR DESCRIPTION
* Update tool to use annotations instead of assets. 
* Consolidate asset json payload parsing into utils.js
* Change `id` variables to reflect what is being stored, `assetId` or `annotationId`

Important:
* For the moment, don't insert "items" from the Mediathread Collection
* Saved sequences will need to be cleared out. This includes SequenceAssets and MediaSequenceElements.