### PR TITLE
Remove extractAssetData

### DIFF
--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -1,5 +1,5 @@
 import {
-    collisionPresent, extractAssetData, formatTimecode, pad2,
+    collisionPresent, formatTimecode, pad2,
     getSeparatedTimeUnits
 } from '../src/utils.js';
 
@@ -49,23 +49,6 @@ describe('collisionPresent', () => {
                 end_time: 11
             }
         ], 30, 1.1, 1.15)).toBe(false);
-    });
-});
-
-describe('extractAssetData', () => {
-    it('handles bogus input', () => {
-        expect(extractAssetData('').assetId).toBe(null);
-        expect(extractAssetData('').annotationId).toBe(null);
-        expect(extractAssetData(null).assetId).toBe(null);
-        expect(extractAssetData(null).annotationId).toBe(null);
-    });
-    it('extracts the url correctly', () => {
-        expect(extractAssetData('/asset/124567/').assetId).toBe(124567);
-        expect(extractAssetData('/asset/124567/').annotationId).toBe(null);
-        expect(extractAssetData(
-            '/asset/124567/annotations/15161/').assetId).toBe(124567);
-        expect(extractAssetData(
-            '/asset/124567/annotations/15161/').annotationId).toBe(15161);
     });
 });
 

--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -40,12 +40,11 @@ export default class JuxtaposeApplication extends React.Component {
             // This event will either set the spine video, or
             // trigger the insertion of a media element, depending
             // on what the user is doing.
-            const assetData = extractAssetData(e.detail.annotation);
             const xhr = new Xhr();
-            xhr.getAsset(assetData.assetId)
+            xhr.getAsset(e.detail.assetId)
                .then(function(json) {
                    const ctx = parseAsset(
-                       json, assetData.assetId, assetData.annotationId);
+                       json, e.detail.assetId, e.detail.annotationId);
                    
                    if (e.detail.caller.type === 'spine') {
                        // Set the spine video
@@ -53,8 +52,8 @@ export default class JuxtaposeApplication extends React.Component {
                            spineVideo: {
                                url: ctx.url,
                                host: ctx.host,
-                               assetId: assetData.assetId,
-                               annotationId: assetData.annotationId,
+                               assetId: e.detail.assetId,
+                               annotationId: e.detail.annotationId,
                                annotationStartTime: ctx.startTime,
                                annotationDuration: ctx.duration
                            },
@@ -70,8 +69,8 @@ export default class JuxtaposeApplication extends React.Component {
                            type: ctx.type,
                            host: ctx.host,
                            source: ctx.url,
-                           assetId: assetData.assetId,
-                           annotationId: assetData.annotationId,
+                           assetId: e.detail.assetId,
+                           annotationId: e.detail.annotationId,
                            annotationData: ctx.data,
                            annotationStartTime: ctx.startTime,
                            annotationDuration: ctx.duration

--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactGridLayout from 'react-grid-layout';
 import _ from 'lodash';
 import {
-    collisionPresent, extractAssetData, parseAsset,
+    collisionPresent, parseAsset,
     formatTimecode, loadMediaData, loadTextData
 } from './utils.js';
 import MediaTrack from './MediaTrack.jsx';

--- a/src/utils.js
+++ b/src/utils.js
@@ -65,24 +65,6 @@ export function ellipsis(str, limit, append) {
     }
 };
 
-export function extractAssetData(s) {
-    let id = null;
-    let annotationId = null;
-    if (s) {
-        const matches = s.match(/\/asset\/(\d+)(\/annotations\/(\d+))?\/$/i);
-        if (matches[1]) {
-            id = parseInt(matches[1], 10);
-        }
-        if (matches[3]) {
-            annotationId = parseInt(matches[3], 10);
-        }
-    }
-    return {
-        'assetId': id,
-        'annotationId': annotationId
-    };
-}
-
 /**
  * extractAnnotation
  *


### PR DESCRIPTION
Mediathread PR (https://github.com/ccnmtl/mediathread/pull/1076) passes the
assetId and annotationId through directly, eliminating the need for additional
parsing in the tool.