### PR TITLE
Remove out-of-bounds elements when spine is an asset

### DIFF
--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -52,10 +52,11 @@ export default class JuxtaposeApplication extends React.Component {
                        // track elements that aren't in this selection's range.
                        // If that's the case, warn the user and allow them to
                        // cancel the action.
-                       if (hasOutOfBoundsElement(
-                           ctx.duration,
-                           self.state.mediaTrack,
-                           self.state.textTrack)
+                       if (!ctx.duration ||
+                           hasOutOfBoundsElement(
+                               ctx.duration,
+                               self.state.mediaTrack,
+                               self.state.textTrack)
                        ) {
                            self.setState({
                                showOutOfBoundsModal: true,
@@ -217,7 +218,7 @@ export default class JuxtaposeApplication extends React.Component {
                     ref={(c) => this._primaryVid = c}
                     readOnly={this.props.readOnly}
                     onDuration={this.onSpineDuration.bind(this)}
-                    onVideoEnd={this.onSpineVideoEnd.bind(this)}
+                    onEnded={this.onSpineVideoEnded.bind(this)}
                     playing={this.state.isPlaying}
                     onProgress={this.onSpineProgress.bind(this)}
                     onPlay={this.onSpinePlay.bind(this)}
@@ -412,11 +413,17 @@ export default class JuxtaposeApplication extends React.Component {
         this._primaryVid.player.seekTo(percentage);
         this._secondaryVid.seekTo(percentage);
     }
-    onSpineVideoEnd() {
+    onSpineVideoEnded() {
         this.setState({isPlaying: false});
     }
     onSpineDuration(duration) {
-        this.setState({duration: duration});
+        this.setState({
+            duration: duration,
+            mediaTrack: removeOutOfBoundsElements(
+                duration, this.state.mediaTrack),
+            textTrack: removeOutOfBoundsElements(
+                duration, this.state.textTrack)
+        });
     }
     onSpineProgress(state) {
         if (typeof state.played !== 'undefined') {

--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -424,6 +424,7 @@ export default class JuxtaposeApplication extends React.Component {
             textTrack: removeOutOfBoundsElements(
                 duration, this.state.textTrack)
         });
+        jQuery(window).trigger('sequenceassignment.set_dirty', {dirty: true});
     }
     onSpineProgress(state) {
         if (typeof state.played !== 'undefined') {
@@ -476,6 +477,7 @@ export default class JuxtaposeApplication extends React.Component {
                 newDuration, this.state.textTrack)
         });
         this.setState({tmpSpineVid: null});
+        jQuery(window).trigger('sequenceassignment.set_dirty', {dirty: true});
     }
     /**
      * Get the item in textTrack or mediaTrack, based on the activeItem

--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -52,11 +52,14 @@ export default class JuxtaposeApplication extends React.Component {
                        // track elements that aren't in this selection's range.
                        // If that's the case, warn the user and allow them to
                        // cancel the action.
-                       if (!ctx.duration ||
-                           hasOutOfBoundsElement(
-                               ctx.duration,
-                               self.state.mediaTrack,
-                               self.state.textTrack)
+                       if (
+                           (!ctx.duration ||
+                            hasOutOfBoundsElement(
+                                ctx.duration,
+                                self.state.mediaTrack,
+                                self.state.textTrack)) &&
+                           (self.state.mediaTrack.length > 0 ||
+                            self.state.textTrack.length > 0)
                        ) {
                            self.setState({
                                showOutOfBoundsModal: true,

--- a/src/OutOfBoundsModal.jsx
+++ b/src/OutOfBoundsModal.jsx
@@ -9,7 +9,7 @@ export default class OutOfBoundsModal extends React.Component {
         <Modal.Title>Warning</Modal.Title>
     </Modal.Header>
     <Modal.Body>
-        Using this selection as the primary video will cause some
+        Using this selection as the primary video may cause some
         track elements to be removed.
     </Modal.Body>
     <Modal.Footer>

--- a/src/SpineVideo.jsx
+++ b/src/SpineVideo.jsx
@@ -67,9 +67,9 @@ export default class SpineVideo extends React.Component {
                     width={480}
                     height={360}
                     playing={this.props.playing}
-                    onLoadedMetadata={this.onLoadedMetadata.bind(this)}
                     onEnded={this.onEnded.bind(this)}
                     url={url}
+                    onReady={this.onReady}
                     onDuration={this.props.onDuration}
                     onProgress={this.props.onProgress}
                     onPlay={this.props.onPlay}
@@ -81,12 +81,8 @@ export default class SpineVideo extends React.Component {
                 {editSpineButton}
         </div>;
     }
-    onLoadedMetadata(e) {
-        const vid = e.target;
-        this.props.callbackParent(vid.currentTime, vid.duration);
-    }
     onEnded(e) {
-        this.props.onVideoEnd();
+        this.props.onEnded();
     }
     // TODO: handle playback finish event
     onClickReviseSpine() {

--- a/src/SpineVideo.jsx
+++ b/src/SpineVideo.jsx
@@ -69,7 +69,6 @@ export default class SpineVideo extends React.Component {
                     playing={this.props.playing}
                     onEnded={this.onEnded.bind(this)}
                     url={url}
-                    onReady={this.onReady}
                     onDuration={this.props.onDuration}
                     onProgress={this.props.onProgress}
                     onPlay={this.props.onPlay}

--- a/src/utils.js
+++ b/src/utils.js
@@ -143,6 +143,10 @@ export function hasOutOfBoundsElement(duration, mediaTrack, textTrack) {
 }
 
 export function removeOutOfBoundsElements(duration, track) {
+    if (!duration) {
+        // Can't remove anything if there's no duration.
+        return track;
+    }
     let newTrack = [];
     for (let i = 0; i < track.length; i++) {
         const el = track[i];


### PR DESCRIPTION
We need to trigger this removal from the onDuration callback since it
doesn't come through from Mediathread's API.