### PR TITLE
onSaveClick: handle an empty save situation

### DIFF
--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -437,6 +437,14 @@ export default class JuxtaposeApplication extends React.Component {
         }
     }
     onSaveClick() {
+        if (!this.state.spineVid) {
+            // nothing to save yet
+            jQuery(window).trigger(
+                'sequenceassignment.on_save_success', {
+                    submittable: false});
+            return;
+        }
+        
         const xhr = new Xhr();
         const self = this;
         xhr.createOrUpdateSequenceAsset(


### PR DESCRIPTION
The containing project may issue a save request before the user has
completed any work. In this case, simply signal success.