### PR TITLE
Improve duration logic - PMT #109344

### DIFF
--- a/src/SpineVideo.jsx
+++ b/src/SpineVideo.jsx
@@ -86,6 +86,8 @@ export default class SpineVideo extends React.Component {
             const percentage = this.props.spineVid.annotationStartTime /
                 this.props.duration;
             this.player.seekTo(percentage);
+        } else {
+            this.player.seekTo(0);
         }
     }
     // TODO: handle playback finish event


### PR DESCRIPTION
I still can't reliably reproduce the bug we've been seeing, but this
code improves the logic now that I'm aware of onDuration() and onStart()
not being triggered when replacing the video to a selection of the same
asset as described in PMT #109344.

The improvements include:
* Clear the global state.duration when we know it's incorrect. Whenever
  we update the spine video to a new source, this global duration must
  be cleared. If we're replacing the spine video with a selection on the
  same video, the global duration remains the same, so don't clear it.
* Explicitly call player.onStart() whenever the spine video is updated.
  This triggers the code that seeks the video to the correct place, and
  wasn't being called when the video was replaced with a selection of
  itself.
* Never allow the state.time to be negative. This was happening when
  replacing the spine with a selection of itself, and is less necessary
  now that the previous bullet point is addressed, but does make the
  tool more stable.
* Consolidate the spine video updating code in the updateSpineVid
  function.