### PR TITLE
Remove call to spinner destroy - PMT #109366

### DIFF
--- a/src/TimecodeEditor.jsx
+++ b/src/TimecodeEditor.jsx
@@ -28,7 +28,4 @@ export default class TimecodeEditor extends React.Component {
             }
         });
     }
-    componentWillUnmount() {
-        this.$node.spinner('destroy');
-    }
 }


### PR DESCRIPTION
I put this call here after following this example here on using a jQuery
UI element in React:
  http://stackoverflow.com/a/40350880/173630

In practice, this seems to be unnecessary with the way we're using it
and causes problems.