### PR TITLE
Collection widget interaction: revisit

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -78,7 +78,7 @@ export function extractAnnotation(assetCtx, annotationId) {
             if (!annotation.is_global_annotation) {
                 let duration = (annotation.range2 - annotation.range1) || 30;
                 return {
-                    duration: Math.min(30, duration),
+                    duration: duration,
                     range1: annotation.range1,
                     annotationData: annotation.annotation_data
                 };


### PR DESCRIPTION
This PR factors out the essential operations from asset.select & asset.save signals into separate functions within JuxtapositionApp. This PR is dependent on this one. https://github.com/ccnmtl/mediathread/pull/1101

1. addOrEditSpineVideo
    * Original insert of a global annotation. (startTime = 0, duration=undefined)
    * Original insert of a ranged annotation. (startTime= 0 or >, duration=defined)
    * Replace with a global annotation or ranged annotation via revise or edit buttons
2. addMediaTrackElement
    * Original insert of a global annotation. (startTime = 0, duration=undefined)
    * Original insert of a ranged annotation. (startTime= 0 or >, duration=defined)
3. editActiveMediaTrackElement
    * Replace with a global annotation or ranged annotation via the editSelection button.