### PR TITLE
Refactor secondary media element duration update

### DIFF
--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -98,6 +98,22 @@ describe('constrainEndTimeToAvailableSpace', () => {
             constrainEndTimeToAvailableSpace(5.1, 6, 10, track)
         ).toBe(6);
     });
+    it('ignore element at passed index', () => {
+        let track = [
+            {start_time: 0, end_time: 23},
+            {start_time: 24, end_time: 34},
+            {start_time: 36, end_time: 45}
+        ];
+        expect(
+            constrainEndTimeToAvailableSpace(0, 28, 45, track, 0)
+        ).toBe(24);
+        expect(
+            constrainEndTimeToAvailableSpace(0, 18, 45, track, 0)
+        ).toBe(18);
+        expect(
+            constrainEndTimeToAvailableSpace(24, 40, 45, track, 1)
+        ).toBe(36);
+    });
 });
 
 describe('elementsCollide', () => {

--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -592,20 +592,17 @@ export default class JuxtaposeApplication extends React.Component {
             
             const ctx = parseAsset(json, assetId, annotationId);
             const idx = self.state.activeItem[1];
+            const timecode = self.state.mediaTrack[idx].start_time;
             
             state.mediaTrack[idx].media = annotationId;
             state.mediaTrack[idx].annotationData = ctx.data;
             state.mediaTrack[idx].annotationStartTime = ctx.startTime;
-
-            // TODO: integrate with constrainEndTimeToAvailableSpace
-            // the function needs to understand this item is being updated
-            // otherwise, it detects a collision with itself.
-            if (ctx.duration < state.mediaTrack[idx].annotationDuration) {
-                state.mediaTrack[idx].end_time =
-                    state.mediaTrack[idx].start_time + ctx.duration;
-            }
-            state.mediaTrack[idx].annotationDuration = ctx.duration;
-            
+            state.mediaTrack[idx].annotationDuration = ctx.duration;            
+            const endTime =  constrainEndTimeToAvailableSpace(
+                timecode, timecode + ctx.duration,
+                self.sequenceDuration(),
+                self.state.mediaTrack, idx);
+            state.mediaTrack[idx].end_time = endTime;
             self.setState(state);
         });
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,7 +72,7 @@ export function collisionPresent(track, duration, start_time, end_time) {
  *     sequence duration.
  */
 export function constrainEndTimeToAvailableSpace(
-    requestedStartTime, requestedEndTime, sequenceDuration, track
+    requestedStartTime, requestedEndTime, sequenceDuration, track, idx
 ) {
     if (requestedEndTime <= requestedStartTime) {
         throw new Error('end time must be greater than start time.');
@@ -86,9 +86,14 @@ export function constrainEndTimeToAvailableSpace(
         start_time: requestedStartTime,
         end_time: requestedEndTime
     };
-    for (let e of track) {
-        if (elementsCollide(requestedEl, e)) {
-            return e.start_time;
+    for (let i=0; i < track.length; i++) {
+        // ignore the element at idx
+        if (i === idx) {
+            continue;
+        }
+        
+        if (elementsCollide(requestedEl, track[i])) {
+            return track[i].start_time;
         }
     }
 


### PR DESCRIPTION
When a secondary media element's underlying selection is updated, the duration
and therefore the end time may change. Integrate the update with
constrainEndTimeToAvailableSpace to ensure no collsions take place. Update the
constrain function to ignore the element being updated.