### PR TITLE
Timecode spinner improvements - PMT #109377

### DIFF
--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -173,11 +173,12 @@ describe('formatTimecode', () => {
         expect(formatTimecode(9999)).toBe('166:39:00');
     });
     it('formats centiseconds correctly', () => {
-        expect(formatTimecode(0.2398572)).toBe('00:00:24');
-        expect(formatTimecode(55.1871)).toBe('00:55:19');
+        expect(formatTimecode(0.2398572)).toBe('00:00:23');
+        expect(formatTimecode(55.1871)).toBe('00:55:18');
         expect(formatTimecode(60.1241)).toBe('01:00:12');
-        expect(formatTimecode(81.3299)).toBe('01:21:33');
+        expect(formatTimecode(81.3299)).toBe('01:21:32');
         expect(formatTimecode(9999.114)).toBe('166:39:11');
+        expect(formatTimecode(1.999602)).toBe('00:01:99');
     });
 });
 

--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -1,7 +1,7 @@
 import {
     collisionPresent, constrainEndTimeToAvailableSpace,
     elementsCollide, formatTimecode, pad2,
-    getSeparatedTimeUnits
+    getSeparatedTimeUnits, parseTimecode
 } from '../src/utils.js';
 
 describe('collisionPresent', () => {
@@ -179,6 +179,30 @@ describe('formatTimecode', () => {
         expect(formatTimecode(81.3299)).toBe('01:21:32');
         expect(formatTimecode(9999.114)).toBe('166:39:11');
         expect(formatTimecode(1.999602)).toBe('00:01:99');
+    });
+});
+
+describe('parseTimecode', () => {
+    it('parses timecodes correctly', () => {
+        expect(parseTimecode('00:00:00')).toBe(0);
+        expect(parseTimecode('00:55:00')).toBe(55);
+        expect(parseTimecode('01:00:00')).toBe(60);
+        expect(parseTimecode('01:21:00')).toBe(81);
+        expect(parseTimecode('166:39:00')).toBe(9999);
+        expect(parseTimecode('00:00:23')).toBe(0.23);
+        expect(parseTimecode('00:55:18')).toBe(55.18);
+        expect(parseTimecode('01:00:12')).toBe(60.12);
+        expect(parseTimecode('01:21:32')).toBe(81.32);
+        expect(parseTimecode('166:39:11')).toBe(9999.11);
+        expect(parseTimecode('00:01:99')).toBe(1.99);
+    });
+    it('is flexible about zeroes', () => {
+        expect(parseTimecode('00:00:0')).toBe(0);
+        expect(parseTimecode('0:0:0')).toBe(0);
+        expect(parseTimecode('0:00:0')).toBe(0);
+        expect(parseTimecode('0:00:00')).toBe(0);
+        expect(parseTimecode('0:55:00')).toBe(55);
+        expect(parseTimecode('00:0:12')).toBe(0.12);
     });
 });
 

--- a/src/TimecodeEditor.jsx
+++ b/src/TimecodeEditor.jsx
@@ -10,7 +10,6 @@ export default class TimecodeEditor extends React.Component {
     render() {
         return <div className="jux-timecode-editor">
     <input ref="spinner" min="0" required
-           onChange={this.props.onChange}
            defaultValue={formatTimecode(this.props.timecode)} />
         </div>;
     }

--- a/src/TimecodeEditor.jsx
+++ b/src/TimecodeEditor.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {parseTimecode} from './utils.js';
+import {formatTimecode, parseTimecode} from './utils.js';
 
 /**
  * TimecodeEditor is a form widget that handles updating a
@@ -11,13 +11,12 @@ export default class TimecodeEditor extends React.Component {
         return <div className="jux-timecode-editor">
     <input ref="spinner" min="0" required
            onChange={this.props.onChange}
-           value={this.props.timecode * 100} />
+           defaultValue={formatTimecode(this.props.timecode)} />
         </div>;
     }
     componentDidMount() {
-        this.$node = jQuery(this.refs.spinner);
         const self = this;
-        this.$node.timecodespinner({
+        jQuery(this.refs.spinner).timecodespinner({
             change: function(e) {
                 const seconds = parseTimecode(e.target.value);
                 self.props.onChange(seconds);
@@ -27,5 +26,8 @@ export default class TimecodeEditor extends React.Component {
                 self.props.onChange(seconds);
             }
         });
+    }
+    componentWillUnmount() {
+        jQuery(this.refs.spinner).timecodespinner('destroy');
     }
 }

--- a/src/timecodeSpinner.js
+++ b/src/timecodeSpinner.js
@@ -7,11 +7,12 @@ export function defineTimecodeSpinner() {
 
     jQuery.widget('ui.timecodespinner', jQuery.ui.spinner, {
         options: {
+            min: 0,
             // One 'step' is a second. This widget represents the
             // timecode in centiseconds.
             step: 100,
             // page-up / page-down will change the minute.
-            page: 60,
+            page: 60
         },
         _parse: function(value) {
             if (typeof value === 'string') {
@@ -25,7 +26,8 @@ export function defineTimecodeSpinner() {
             return value;
         },
         _format: function(value) {
-            return formatTimecode(value / 100);
+            const formatted = formatTimecode(value / 100);
+            return formatted;
         }
     });
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -264,8 +264,15 @@ export function parseAsset(json, assetId, annotationId) {
 export function getSeparatedTimeUnits(totalSeconds) {
     const minutes = Math.floor(totalSeconds / 60);
     const seconds = Math.floor(totalSeconds - minutes * 60);
-    const centiseconds = Math.round(
+
+    // Really this should be Math.round() instead of Math.floor(),
+    // but using Math.round() allows the centiseconds to be
+    // 100 if totalSeconds is something like 1.999602. That creates
+    // some code complexity, so I'm compromising by introducing
+    // this small imprecision.
+    const centiseconds = Math.floor(
         (totalSeconds - (minutes * 60) - seconds) * 100);
+
     return [minutes, seconds, centiseconds];
 }
 


### PR DESCRIPTION
These changes improve the timecode spinner behavior.

Remaining issues:
* When you drag the start time all the way down below 0, the duration
  begins to shrink! Nothing should happen in this case.