### PR TITLE
Disallow Global Annotations for Secondary Elements

### DIFF
--- a/src/MediaTrack.jsx
+++ b/src/MediaTrack.jsx
@@ -12,7 +12,7 @@ export default class MediaTrack extends Track {
             'type': 'track',
             'timecode': absoluteTimecode
         }
-        createCollectionWidget('all', caller);
+        createCollectionWidget('all', false, caller);
     }
     getHelpText() {
         return "Click on this track to place video and audio elements";

--- a/src/SpineDisplay.jsx
+++ b/src/SpineDisplay.jsx
@@ -95,7 +95,7 @@ export default class SpineDisplay extends React.Component {
             'type': 'spine',
             'timecode': 0
         };
-        createCollectionWidget('video', caller);
+        createCollectionWidget('video', true, caller);
     }
     onClickEditSpine(e) {
         let caller = {

--- a/src/mediathreadCollection.js
+++ b/src/mediathreadCollection.js
@@ -7,8 +7,9 @@
  * of React here.
  */
 
-export function createCollectionWidget(mediaType, caller) {
+export function createCollectionWidget(mediaType, allowAssets, caller) {
     jQuery(window).trigger('collection.open', [{
+        'allowAssets': allowAssets,
         'media_type': mediaType,
         'disable': mediaType === 'all' ? [] : ['media_type'],
         'caller': caller


### PR DESCRIPTION
The lack of duration on these elements is problematic. Shut this down for the short-term.

related: https://github.com/ccnmtl/mediathread/pull/1104