### PR TITLE
Fix bug where spinning below zero alters track duration - PMT #109377

### DIFF
--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -240,13 +240,13 @@ export default class JuxtaposeApplication extends React.Component {
             return;
         }
 
-        if (newData.source) {
+        if (typeof newData.source !== 'undefined') {
             item.source = newData.source;
         }
-        if (newData.start_time) {
+        if (typeof newData.start_time !== 'undefined') {
             item.start_time = newData.start_time;
         }
-        if (newData.end_time) {
+        if (typeof newData.end_time !== 'undefined') {
             item.end_time = newData.end_time;
         }
 


### PR DESCRIPTION
This fixes an interesting bug where the element's start_time could never
reach zero because of a boolean check in the code. Because start_time
would get stuck at 1, the end_time kept subtracting 1 from itself. 0 is
a valid start_time, but evaluates to false. I've updated
onTrackElementUpdate to instead check if the value is defined.