### PR TITLE
Timecode spinner fixes - PMT #109390

### DIFF
--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -162,6 +162,19 @@ describe('elementsCollide', () => {
         expect(elementsCollide(e1, e2)).toBe(false);
         expect(elementsCollide(e2, e1)).toBe(false);
     });
+    it('detects collision when one element completely surrounds the other',
+       () => {
+           let e1 = {
+               start_time: 1,
+               end_time: 2
+           };
+           let e2 = {
+               start_time: 0.5,
+               end_time: 3
+           };
+           expect(elementsCollide(e1, e2)).toBe(true);
+           expect(elementsCollide(e2, e1)).toBe(true);
+       });
 });
 
 describe('formatTimecode', () => {

--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -234,19 +234,21 @@ export default class JuxtaposeApplication extends React.Component {
             collisionPresent(
                 newTrack,
                 this.state.duration,
-                newData.start_time || item.start_time,
-                newData.end_time || item.end_time)
+                (_.isNumber(newData.start_time) ?
+                 newData.start_time : item.start_time),
+                (_.isNumber(newData.end_time) ?
+                 newData.end_time : item.end_time))
         ) {
             return;
         }
 
-        if (typeof newData.source !== 'undefined') {
+        if (_.isString(newData.source)) {
             item.source = newData.source;
         }
-        if (typeof newData.start_time !== 'undefined') {
+        if (_.isNumber(newData.start_time)) {
             item.start_time = newData.start_time;
         }
-        if (typeof newData.end_time !== 'undefined') {
+        if (_.isNumber(newData.end_time)) {
             item.end_time = newData.end_time;
         }
 

--- a/src/TimecodeEditor.jsx
+++ b/src/TimecodeEditor.jsx
@@ -9,9 +9,17 @@ import {formatTimecode, parseTimecode} from './utils.js';
 export default class TimecodeEditor extends React.Component {
     render() {
         return <div className="jux-timecode-editor">
-    <input ref="spinner" min="0" required
+    <input ref="spinner" min={this.props.min} required
            defaultValue={formatTimecode(this.props.timecode)} />
         </div>;
+    }
+    componentWillReceiveProps(props) {
+        // Because this is an uncontrolled input, we need to manually
+        // update the value of the input when the active element is
+        // updated.
+        if (parseTimecode(this.refs.spinner.value) !== props.timecode) {
+            this.refs.spinner.value = formatTimecode(props.timecode);
+        }
     }
     componentDidMount() {
         const self = this;

--- a/src/TrackElementManager.jsx
+++ b/src/TrackElementManager.jsx
@@ -40,6 +40,7 @@ export default class TrackElementManager extends React.Component {
                 Start &nbsp;{formatTimecode(activeItem.start_time)}
             </label><br />    
             <TimecodeEditor
+                min={0}
                 timecode={activeItem.start_time}
                 onChange={this.onStartTimeChange.bind(this)}
             />
@@ -50,6 +51,7 @@ export default class TrackElementManager extends React.Component {
                 Duration &nbsp;{formatTimecode(duration)}
             </label><br />
             <TimecodeEditor
+                min={100}
                 timecode={activeItem.end_time - activeItem.start_time}
                 onChange={this.onDurationChange.bind(this)}
             />

--- a/src/timecodeSpinner.js
+++ b/src/timecodeSpinner.js
@@ -7,7 +7,6 @@ export function defineTimecodeSpinner() {
 
     jQuery.widget('ui.timecodespinner', jQuery.ui.spinner, {
         options: {
-            min: 0,
             // One 'step' is a second. This widget represents the
             // timecode in centiseconds.
             step: 100,


### PR DESCRIPTION
* Fix case where a duration of 0 freezes the spinner and causes JS error
  (I've updated the duration spinner to disallow an element duration
  of less than one second).
* Fix bug where updating to a start_time of zero could cause JS errors
  and element collision.
* Selecting a new track element now updates the timecodes in the
  TrackElementManager