### PR TITLE
Fade in opacity instead of display - PMT #109392

### DIFF
--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -130,10 +130,10 @@ export default class JuxtaposeApplication extends React.Component {
                    submittable: self.isBaselineWorkCompleted()
                });
                jQuery('#sequence>.loader').hide();
-               jQuery('#jux-container').fadeIn();
+               jQuery('#jux-container').fadeTo('fast', 1);
            }).catch(function() {
                jQuery('#sequence>.loader').hide();
-               jQuery('#jux-container').fadeIn();
+               jQuery('#jux-container').fadeTo('fast', 1);
            });
     }
     render() {


### PR DESCRIPTION
So the sequence tool container doesn't jump in height during the loading
process.