### PR TITLE
Don't attempt to load sequence tool when dom element doesn't exist

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,11 +3,13 @@ import ReactDOM from 'react-dom';
 import JuxtaposeApplication from './JuxtaposeApplication.jsx';
 
 
-ReactDOM.render(
-    <JuxtaposeApplication
-        readOnly={(view && view.submitted) || false}
-        primaryInstructions={view && view.primaryInstructions || ''}
-        secondaryInstructions={view && view.secondaryInstructions || ''}
-    />,
-    document.getElementById('jux-container')
-);
+if (document.getElementById('jux-container')) {
+    ReactDOM.render(
+        <JuxtaposeApplication
+            readOnly={(view && view.submitted) || false}
+            primaryInstructions={view && view.primaryInstructions || ''}
+            secondaryInstructions={view && view.secondaryInstructions || ''}
+        />,
+        document.getElementById('jux-container')
+    );
+}


### PR DESCRIPTION
This addresses this JS error:
> Uncaught Error: _registerComponent(...): Target container is not a DOM
> element.

Which occurs when you're an instructor and you're viewing a sequence
assignment but not a response.