### PR TITLE
Don't setDirty in onSpineDuration - PMT #109410

### DIFF
--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -416,7 +416,6 @@ export default class JuxtaposeApplication extends React.Component {
             textTrack: removeOutOfBoundsElements(
                 duration, this.state.textTrack)
         });
-        jQuery(window).trigger('sequenceassignment.set_dirty', {dirty: true});
     }
     onSpineProgress(state) {
         if (typeof state.played !== 'undefined') {


### PR DESCRIPTION
This was causing the dirty state to be set whenever a spine video loaded
its duration, causing the referenced bug. The intention here was that
the dirty state should be set whenever track elements could have been
removed, which could occur with the removeOutOfBoundsElements() calls in
this function. But this case is already handled in
onOutOfBoundsConfirmClick().