### PR TITLE
Add "140 character limit" note to text annotation adder

### DIFF
--- a/src/TextAnnotationAdder.jsx
+++ b/src/TextAnnotationAdder.jsx
@@ -30,6 +30,7 @@ export default class TextAnnotationAdder extends React.Component {
                       maxLength={140}
                       onChange={this.onTextChange.bind(this)}
                       value={this.state.value} />
+            <div className="helptext">140 character limit</div>
             <br />
             <button className="btn btn-primary right" type="submit">
                 Submit


### PR DESCRIPTION
Just like in the TrackElementManager

![2017-01-04-114135_638x241_scrot](https://cloud.githubusercontent.com/assets/59292/21650418/e6fe1c26-d272-11e6-9b5e-20f2cf63d648.png)
