### PR TITLE
Refactor trackItemDragHandler - PMT #109430

### DIFF
--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -2,7 +2,8 @@ import {
     collisionPresent, constrainEndTimeToAvailableSpace,
     getElement,
     elementsCollide, formatTimecode, pad2,
-    getSeparatedTimeUnits, parseTimecode
+    getSeparatedTimeUnits, parseTimecode,
+    trackItemDragHandler
 } from '../src/utils.js';
 
 describe('collisionPresent', () => {
@@ -242,9 +243,9 @@ describe('pad2', () => {
 
 describe('getElement', () => {
     it('handles empty data appropriately', () => {
-        expect(getElement([], 3.2)).toBeNull;
-        expect(getElement([], 0)).toBeNull;
-        expect(getElement([], -1)).toBeNull;
+        expect(getElement([], 3.2)).toBeNull();
+        expect(getElement([], 0)).toBeNull();
+        expect(getElement([], -1)).toBeNull();
     });
     it('returns an accurate current item', () => {
         let data = [{
@@ -254,7 +255,7 @@ describe('getElement', () => {
                 type: 'vid',
                 source: 'video.mp4'
         }];
-        expect(getElement(data, 3.2)).toBeNull;
+        expect(getElement(data, 3.2)).toBeNull();
         expect(getElement(data, 55)).toEqual({
             key: 0,
             start_time: 5,
@@ -286,7 +287,7 @@ describe('getElement', () => {
                 source: 'video.mp4'
             },
         ];
-        expect(getElement(data, 3.2)).toBeNull;
+        expect(getElement(data, 3.2)).toBeNull();
         expect(getElement(data, 55)).toEqual({
             key: 0,
             start_time: 5,
@@ -301,7 +302,7 @@ describe('getElement', () => {
             type: 'vid',
             source: 'video.mp4'
         });
-        expect(getElement(data, 60.5)).toBeNull;
+        expect(getElement(data, 60.5)).toBeNull();
         expect(getElement(data, 63.88)).toEqual({
             key: 1,
             start_time: 63,
@@ -309,6 +310,95 @@ describe('getElement', () => {
             type: 'vid',
             source: 'video.mp4'
         });
-        expect(getElement(data, 75)).toBeNull;
+        expect(getElement(data, 75)).toBeNull();
+    });
+});
+
+describe('trackItemDragHandler', () => {
+    it('returns null when there\'s no change', () => {
+        const textTrack = [
+            {
+                end_time: 2,
+                key: 0,
+                source: 'a',
+                start_time: 0,
+                type: 'txt'
+            },
+            {
+                end_time: 4,
+                key: 1,
+                source: 'b',
+                start_time: 3,
+                type: 'txt'
+            }
+        ];
+        let draggedItem = {
+            'static': false,
+            moved: true,
+            h: 48,
+            i: '1',
+            w: 33.333333333333336,
+            x: 100,
+            y: 0
+        }
+        expect(trackItemDragHandler(textTrack, draggedItem, 30)).toBeNull();
+
+        draggedItem = {
+            'static': false,
+            moved: false,
+            h: 48,
+            i: '1',
+            w: 33.333333333333336,
+            x: 100,
+            y: 0
+        }
+        expect(trackItemDragHandler(textTrack, draggedItem, 30)).toBeNull();
+    });
+
+    it('returns the new track when there is a change', () => {
+        const textTrack = [
+            {
+                end_time: 2,
+                key: 0,
+                source: 'a',
+                start_time: 0,
+                type: 'txt'
+            },
+            {
+                end_time: 4,
+                key: 1,
+                source: 'b',
+                start_time: 3,
+                type: 'txt'
+            }
+        ];
+        let draggedItem = {
+            'static': false,
+            moved: true,
+            h: 48,
+            i: '1',
+            w: 33.333333333333336,
+            x: 148,
+            y: 0
+        }
+
+        const newTrack = [
+            {
+                end_time: 2,
+                key: 0,
+                source: 'a',
+                start_time: 0,
+                type: 'txt'
+            },
+            {
+                end_time: 5.4399999999999995,
+                key: 1,
+                source: 'b',
+                start_time: 4.4399999999999995,
+                type: 'txt'
+            }
+        ];
+        expect(trackItemDragHandler(textTrack, draggedItem, 30)).toEqual(
+            newTrack);
     });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -408,9 +408,9 @@ export function trackItemDragHandler(origTrack, item, sequenceDuration) {
 
     // Check that the value actually needs to be updated.
     if (startTime === origElem.start_time ||
-        // Allow just over a hundredth of a second margin of
-        // error. This can occur when clicking the track elements.
-        Math.abs(startTime - origElem.start_time) <= 0.015
+        // Allow a small margin of error. This can occur when clicking
+        // the track elements.
+        Math.abs(startTime - origElem.start_time) <= (sequenceDuration * 0.001)
        ) {
         return null;
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,7 +91,7 @@ export function constrainEndTimeToAvailableSpace(
         if (i === idx) {
             continue;
         }
-        
+
         if (elementsCollide(requestedEl, track[i])) {
             return track[i].start_time;
         }
@@ -248,7 +248,7 @@ export function parseAsset(json, assetId, annotationId) {
     const annotation = extractAnnotation(assetCtx, annotationId);
     const type = assetCtx.primary_type === 'image' ? 'img' : 'vid';
     const duration = type === 'img' ? 30 : annotation.duration;
-    
+
     return {
         url: source.url,
         host: source.host,
@@ -382,4 +382,45 @@ export function reassignKeys(track) {
     for (let i = 0; i < track.length; i++) {
         track[i].key = i;
     }
+}
+
+/**
+ * This function handles the drag stop event for track items.
+ *
+ * It takes a track array, the dragged grid item, and the sequence
+ * duration.
+ *
+ * It returns the new state of the track, which the caller can save
+ * with setState. If there are no necessary changes to the track,
+ * this function returns null.
+ */
+export function trackItemDragHandler(origTrack, item, sequenceDuration) {
+    // react-grid-layout sets a 'moved' flag on the dragged item.
+    if (item.moved === false) {
+        return null;
+    }
+
+    const origElem = _.find(origTrack, ['key', parseInt(item['i'], 10)]);
+    let newTrack = origTrack.slice();
+    const elem = _.find(newTrack, ['key', parseInt(item['i'], 10)]);
+    const percent = item.x / 1000;
+    const startTime = percent * sequenceDuration;
+
+    // Check that the value actually needs to be updated.
+    if (startTime === origElem.start_time ||
+        // Allow just over a hundredth of a second margin of
+        // error. This can occur when clicking the track elements.
+        Math.abs(startTime - origElem.start_time) <= 0.015
+       ) {
+        return null;
+    }
+
+    const len = elem.end_time - elem.start_time;
+    elem.start_time = startTime;
+    elem.end_time = elem.start_time + len;
+
+    newTrack = _.reject(newTrack, ['key', elem.key]);
+    newTrack.push(elem);
+    newTrack = _.sortBy(newTrack, 'key');
+    return newTrack;
 }


### PR DESCRIPTION
* This addresses the problem where the dirty state is set to true when
  you only click a track element.
* In the jest tests I had `.toBeNull` everywhere, but I found out this
  doesn't fail when it should. I changed them all to `.toBeNull()`.