### PR TITLE
Improve spinner validation - PMT #109452, #109465

### DIFF
--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -219,6 +219,14 @@ describe('parseTimecode', () => {
         expect(parseTimecode('0:55:00')).toBe(55);
         expect(parseTimecode('00:0:12')).toBe(0.12);
     });
+    it('returns null on invalid input', () => {
+        expect(parseTimecode('00:aa:0')).toBeNull();
+        expect(parseTimecode('00:0')).toBeNull();
+        expect(parseTimecode('0:00gfw0')).toBeNull();
+        expect(parseTimecode('0:00:f0')).toBeNull();
+        expect(parseTimecode('0:55:w0')).toBeNull();
+        expect(parseTimecode('x0:0:12')).toBeNull();
+    });
 });
 
 describe('getSeparatedTimeUnits', () => {

--- a/src/TimecodeEditor.jsx
+++ b/src/TimecodeEditor.jsx
@@ -26,11 +26,22 @@ export default class TimecodeEditor extends React.Component {
         jQuery(this.refs.spinner).timecodespinner({
             change: function(e) {
                 const seconds = parseTimecode(e.target.value);
-                self.props.onChange(seconds);
+                if (seconds) {
+                    self.props.onChange(seconds);
+                }
+
+                if (self.props.timecode !== self.refs.spinner.value) {
+                    // Update the input value from the application state
+                    // when the user puts it in an invalid state.
+                    self.refs.spinner.value = formatTimecode(
+                        self.props.timecode);
+                }
             },
             spin: function(e) {
                 const seconds = parseTimecode(e.target.value);
-                self.props.onChange(seconds);
+                if (seconds) {
+                    self.props.onChange(seconds);
+                }
             }
         });
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -297,9 +297,14 @@ export function getCentiseconds(totalSeconds) {
 
 export function parseTimecode(str) {
     const parts = str.split(':');
-    return (Number(parts[0]) * 60) +
-        Number(parts[1]) +
-        (Number(parts[2]) / 100);
+    const col1 = Number(parts[0]);
+    const col2 = Number(parts[1]);
+    const col3 = Number(parts[2]);
+    if (_.isFinite(col1) && _.isFinite(col2) && _.isFinite(col3)) {
+        return (col1 * 60) + col2 + (col3 / 100);
+    } else {
+        return null;
+    }
 }
 
 export function formatTimecode(totalSeconds) {


### PR DESCRIPTION
Always reset the timecode spinner to a valid state. Prevent NaN from
occuring.