### PR TITLE
TrackElementManager Enter key fix - PMT #109459

### DIFF
--- a/src/TrackElementManager.jsx
+++ b/src/TrackElementManager.jsx
@@ -34,7 +34,7 @@ export default class TrackElementManager extends React.Component {
     </button>
     <div className="track-icon left"></div>
     <div className="left">
-        <form className="form-inline">
+        <div className="form-inline">
         <div className="form-group">
             <label>
                 Start &nbsp;{formatTimecode(activeElement.start_time)}
@@ -75,7 +75,7 @@ export default class TrackElementManager extends React.Component {
             </button>
         </div>
         <div className="clearfix"></div>
-        </form>
+        </div>
         <DeleteElementModal
             showing={this.state.showDeleteElementModal}
             onCloseClick={this.onDeleteCloseClick.bind(this)}


### PR DESCRIPTION
Don't trigger the 'Edit Selection' button when pressing enter in the
TrackElementManager form. Since we're not using any traditional form
events here, I've just changed the form to a div.

In fact, when a timecode input is selected, pressing enter should
trigger the 'change' event. I'll do that in a separate PR.