### PR TITLE
Prevent initial seek from autoplaying spine - PMT #109437

### DIFF
--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -424,8 +424,10 @@ export default class JuxtaposeApplication extends React.Component {
         }
     }
     onSpinePlay() {
+        // Make sure the spine video stays paused
         if (!this.state.playing) {
             this.setState({playing: true});
+            this.setState({playing: false});
         }
     }
     onSpinePause() {

--- a/src/SpineDisplay.jsx
+++ b/src/SpineDisplay.jsx
@@ -88,8 +88,6 @@ export default class SpineDisplay extends React.Component {
             const percentage = this.props.spineVid.annotationStartTime /
                 this.props.duration;
             this.player.seekTo(percentage);
-        } else {
-            this.player.seekTo(0);
         }
     }
     onClickReviseSpine() {


### PR DESCRIPTION
This fixes a youtube/vimeo spine issue where the media would start
playing if it hadn't been played yet and you clicked on a point in the
timeline.

This doesn't address secondary media seeking issues (PMT #109457).