### PR TITLE
Include babel-polyfill for old browser support - PMT #109527

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ var BUILD_DIR = path.resolve(__dirname, 'build');
 var APP_DIR = path.resolve(__dirname, 'src');
 
 var config = {
-    entry: APP_DIR + '/index.jsx',
+    entry: ['babel-polyfill', APP_DIR + '/index.jsx'],
     output: {
         path: BUILD_DIR,
         filename: 'bundle.js'


### PR DESCRIPTION
So I'm not able to reproduce this bug in Safari 10, and Zarina's using
Safari 8. Searching around for the error, it looks like it's recommended
to include babel-polyfill in our build process for old browsers that
don't have new globals like Promise defined.
- https://github.com/babel/babelify/issues/22

We already had this in package.json but it wasn't being used. I've
activated it in our webpack config with these instructions:
http://babeljs.io/docs/usage/polyfill/#usage-in-node-browserify-webpack