### PR TITLE
Lock down timecode editor value on spin event - PMT #109462

### DIFF
--- a/src/TimecodeEditor.jsx
+++ b/src/TimecodeEditor.jsx
@@ -43,6 +43,12 @@ export default class TimecodeEditor extends React.Component {
                 if (_.isFinite(seconds)) {
                     self.props.onChange(seconds);
                 }
+                if (self.props.timecode !== self.refs.spinner.value) {
+                    // Lock down the value on spin as well.
+                    self.refs.spinner.value = formatTimecode(
+                        self.props.timecode);
+                    return false;
+                }
             }
         });
     }


### PR DESCRIPTION
This prevents the user from editing the timecode spinner, with the arrow
buttons or with the arrow keys on the keyboard, to a value that's
invalid before the change event happens.