### PR TITLE
Don't seek media on that's hidden - PMT #109528, #109457

### DIFF
--- a/src/AVPlayer.jsx
+++ b/src/AVPlayer.jsx
@@ -76,7 +76,7 @@ export default class AVPlayer extends React.Component {
         }
     }
     seekTo(percentage) {
-        if (!this.player) {
+        if (!this.player || this.props.hidden) {
             return;
         }
 


### PR DESCRIPTION
This will simplify what's going on making it easier to debug. There's no need to
seek on media players that are hidden.