### PR TITLE
Always cue players that are about to play - PMT #109528

### DIFF
--- a/src/AVPlayer.jsx
+++ b/src/AVPlayer.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactPlayer from 'react-player';
+import _ from 'lodash';
 
 
 /**
@@ -11,6 +12,7 @@ export default class AVPlayer extends React.Component {
     constructor(props) {
         super(props);
         this.state = {duration: null};
+        this.throttledSeek = _.throttle(this.seekTo, 200);
     }
     render() {
         let url = this.props.data.source;
@@ -24,6 +26,9 @@ export default class AVPlayer extends React.Component {
         // time.
         const diff = this.props.data.start_time - this.props.time;
         const isAboutToPlay = diff > 0 && diff < 2;
+        if (isAboutToPlay) {
+            this.throttledSeek(this.props.time / this.props.sequenceDuration);
+        }
         const playing = isAboutToPlay ||
                         (!this.props.hidden && this.props.playing);
 

--- a/src/AVPlayer.jsx
+++ b/src/AVPlayer.jsx
@@ -12,7 +12,7 @@ export default class AVPlayer extends React.Component {
     constructor(props) {
         super(props);
         this.state = {duration: null};
-        this.throttledSeek = _.throttle(this.seekTo, 200);
+        this.debouncedSeek = _.debounce(this.seekTo, 200);
     }
     render() {
         let url = this.props.data.source;
@@ -27,7 +27,7 @@ export default class AVPlayer extends React.Component {
         const diff = this.props.data.start_time - this.props.time;
         const isAboutToPlay = diff > 0 && diff < 2;
         if (isAboutToPlay) {
-            this.throttledSeek(this.props.time / this.props.sequenceDuration);
+            this.debouncedSeek(this.props.time / this.props.sequenceDuration);
         }
         const playing = isAboutToPlay ||
                         (!this.props.hidden && this.props.playing);


### PR DESCRIPTION
This adds some code that explicitly seeks the player to the right place
when it's about to play. From what I've seen, seeking on a media element
while the player is visible is working well, and this should address at
least some of the problems where rewinding to before the element and
playing would play the wrong selection.