### PR TITLE
Pause secondary media on the 'play' event when not playing

### DIFF
--- a/src/AVPlayer.jsx
+++ b/src/AVPlayer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactPlayer from 'react-player';
 import _ from 'lodash';
+import BasePlayer from './BasePlayer.jsx';
 
 
 /**
@@ -8,7 +9,7 @@ import _ from 'lodash';
  * that's always rendered on the page, and displayed when the
  * sequence's time is at the right position.
  */
-export default class AVPlayer extends React.Component {
+export default class AVPlayer extends BasePlayer {
     constructor(props) {
         super(props);
         this.state = {duration: null};
@@ -32,30 +33,6 @@ export default class AVPlayer extends React.Component {
         const playing = isAboutToPlay ||
                         (!this.props.hidden && this.props.playing);
 
-        const youtubeConfig = {
-            playerVars: {
-                // Disable fullscreen
-                fs: 0,
-                // Disable keyboard controls
-                disablekb: 1,
-                // Hide video annotations
-                iv_load_policy: 3,
-                modestbranding: 1,
-                rel: 0,
-                showinfo: 0
-            }
-        };
-        const vimeoConfig = {
-            iframeParams: {
-                autopause: 0,
-                badge: 0,
-                byline: 0,
-                fullscreen: 0,
-                portrait: 0,
-                title: 0
-            }
-        };
-
         return <ReactPlayer
                    ref={(ref) => this.player = ref}
                    width={480}
@@ -65,13 +42,24 @@ export default class AVPlayer extends React.Component {
                    hidden={this.props.hidden}
                    onDuration={this.onDuration.bind(this)}
                    onStart={this.onStart.bind(this)}
+                   onPlay={this.onPlay.bind(this)}
                    playing={playing}
-                   youtubeConfig={youtubeConfig}
-                   vimeoConfig={vimeoConfig}
+                   youtubeConfig={this.youtubeConfig}
+                   vimeoConfig={this.vimeoConfig}
                />;
+    }
+    pause() {
+        if (this.player && this.player.player && this.player.player.pause) {
+            this.player.player.pause();
+        }
     }
     onDuration(duration) {
         this.setState({duration: duration});
+    }
+    onPlay() {
+        if (!this.props.playing) {
+            this.pause();
+        }
     }
     onStart() {
         const vid = this.props.data;

--- a/src/BasePlayer.jsx
+++ b/src/BasePlayer.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export default class BasePlayer extends React.Component {
+    constructor(props) {
+        super(props);
+        this.youtubeConfig = {
+            playerVars: {
+                // Disable fullscreen
+                fs: 0,
+                // Disable keyboard controls
+                disablekb: 1,
+                // Hide video annotations
+                iv_load_policy: 3,
+                modestbranding: 1,
+                rel: 0,
+                showinfo: 0
+            }
+        };
+        this.vimeoConfig = {
+            iframeParams: {
+                autopause: 0,
+                badge: 0,
+                byline: 0,
+                fullscreen: 0,
+                portrait: 0,
+                title: 0
+            }
+        };
+    }
+}

--- a/src/SpineDisplay.jsx
+++ b/src/SpineDisplay.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import ReactPlayer from 'react-player'
+import ReactPlayer from 'react-player';
+import BasePlayer from './BasePlayer.jsx';
 import {createCollectionWidget} from './mediathreadCollection.js';
 import {editAnnotationWidget} from './mediathreadCollection.js';
 
-export default class SpineDisplay extends React.Component {
+export default class SpineDisplay extends BasePlayer {
     constructor(props) {
         super(props);
         this.id = 'jux-spine-video';
@@ -48,30 +49,6 @@ export default class SpineDisplay extends React.Component {
                 </button>;
         }
 
-        const youtubeConfig = {
-            playerVars: {
-                // Disable fullscreen
-                fs: 0,
-                // Disable keyboard controls
-                disablekb: 1,
-                // Hide video annotations
-                iv_load_policy: 3,
-                modestbranding: 1,
-                rel: 0,
-                showinfo: 0
-            }
-        };
-        const vimeoConfig = {
-            iframeParams: {
-                autopause: 0,
-                badge: 0,
-                byline: 0,
-                fullscreen: 0,
-                portrait: 0,
-                title: 0
-            }
-        };
-
         return <div className="jux-spine-display">
                 <ReactPlayer
                     id={this.id}
@@ -87,8 +64,8 @@ export default class SpineDisplay extends React.Component {
                     onPlay={this.props.onPlay}
                     onPause={this.props.onPause}
                     progressFrequency={50}
-                    youtubeConfig={youtubeConfig}
-                    vimeoConfig={vimeoConfig}
+                    youtubeConfig={this.youtubeConfig}
+                    vimeoConfig={this.vimeoConfig}
                 />
                 {reviseButton}
                 {editSpineButton}


### PR DESCRIPTION
When clicking the playhead around the timeline, YouTube videos would
start playing even when the global state is paused. This addresses that
issue.

I've also made a "BasePlayer" class for now just as a place of storing
the common youtube / vimeo settings between the primary and secondary
ReactPlayers.