### PR TITLE
Use stricter eslint settings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "extends": ["eslint:recommended", "plugin:react/recommended"],
     "parserOptions": {
         "ecmaVersion": 6,
         "sourceType": "module",

--- a/__tests__/JuxtaposeApplication-test.js
+++ b/__tests__/JuxtaposeApplication-test.js
@@ -1,3 +1,5 @@
+/* eslint-env jest */
+
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import JuxtaposeApplication from '../src/JuxtaposeApplication.jsx';

--- a/__tests__/PlayButton-test.js
+++ b/__tests__/PlayButton-test.js
@@ -1,3 +1,5 @@
+/* eslint-env jest */
+
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import PlayButton from '../src/PlayButton.jsx';

--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -1,3 +1,5 @@
+/* eslint-env jest */
+
 import {
     collisionPresent, constrainEndTimeToAvailableSpace,
     getElement,

--- a/src/AddPrimaryMediaModal.jsx
+++ b/src/AddPrimaryMediaModal.jsx
@@ -20,3 +20,8 @@ export default class AddPrimaryMediaModal extends React.Component {
         </Modal>;
     }
 }
+
+AddPrimaryMediaModal.propTypes = {
+    onCloseClick: React.PropTypes.func.isRequired,
+    showing: React.PropTypes.bool.isRequired
+};

--- a/src/DeleteElementModal.jsx
+++ b/src/DeleteElementModal.jsx
@@ -24,3 +24,9 @@ export default class DeleteElementModal extends React.Component {
         </Modal>;
     }
 }
+
+DeleteElementModal.propTypes = {
+    onCloseClick: React.PropTypes.func.isRequired,
+    onConfirmClick: React.PropTypes.func.isRequired,
+    showing: React.PropTypes.bool.isRequired
+};

--- a/src/ImagePlayer.jsx
+++ b/src/ImagePlayer.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-const ol = require('openlayers');
+import ol from 'openlayers';
 
 // http://stackoverflow.com/questions/35454014/clicks-on-reactjs-components-not-firing-on-an-openlayers-overlay
 // https://github.com/openlayers/ol3/issues/6087
@@ -118,10 +118,10 @@ export default class ImagePlayer extends React.Component {
         }
 
         let attrs = JSON.parse(this.props.annotationData);
-        attrs.type = 'Feature'; // required for ol2 > ol3 migration 
-        
+        attrs.type = 'Feature'; // required for ol2 > ol3 migration
+
         const extent = this.objectProportioned();
-        
+
         const projection = new ol.proj.Projection({
             units: 'pixels',
             extent: extent
@@ -147,18 +147,18 @@ export default class ImagePlayer extends React.Component {
             this.zoomToExtent(extent);
         }
     }
-    shouldComponentUpdate(nextProps, nextState) {
+    shouldComponentUpdate(nextProps) {
         const shouldUpdate = (this.map === undefined && !nextProps.hidden) ||
                               this.props.annotationData !== nextProps.annotationData ||
                               this.props.hidden !== nextProps.hidden;
-        
+
         // destroy the map if annotation data is changing
         if (this.map &&
                 this.props.annotationData !== nextProps.annotationData) {
             this.map.setTarget(null);
             delete this.map;
         }
-        
+
         return shouldUpdate;
     }
     render() {
@@ -171,3 +171,11 @@ export default class ImagePlayer extends React.Component {
         this.initializeMap();
     }
 }
+
+ImagePlayer.propTypes = {
+    annotationData: React.PropTypes.object.isRequired,
+    height: React.PropTypes.number.isRequired,
+    hidden: React.PropTypes.bool.isRequired,
+    url: React.PropTypes.string.isRequired,
+    width: React.PropTypes.number.isRequired
+};

--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -1,5 +1,6 @@
+/* global jQuery */
+
 import React from 'react';
-import ReactGridLayout from 'react-grid-layout';
 import _ from 'lodash';
 import {
     collisionPresent, constrainEndTimeToAvailableSpace,
@@ -73,7 +74,7 @@ export default class JuxtaposeApplication extends React.Component {
             }
         });
 
-        document.addEventListener('sequenceassignment.save', function(e) {
+        document.addEventListener('sequenceassignment.save', function() {
             self.onSaveClick();
         });
 
@@ -321,7 +322,7 @@ export default class JuxtaposeApplication extends React.Component {
         jQuery(window).trigger('sequenceassignment.set_dirty',
                                {dirty: true});
     }
-    onPlayClick(e) {
+    onPlayClick() {
         const newState = !this.state.playing;
         this.setState({playing: newState})
     }
@@ -390,7 +391,7 @@ export default class JuxtaposeApplication extends React.Component {
      * PMT #109344
      */
     onSpineDuration(duration) {
-        this.setState((prevState, props) => {
+        this.setState((prevState) => {
             return {
                 duration: duration,
                 mediaTrack: removeOutOfBoundsElements(
@@ -414,7 +415,7 @@ export default class JuxtaposeApplication extends React.Component {
                 time = Math.min(time, this.sequenceDuration());
             }
 
-            this.setState((prevState, props) => {
+            this.setState((prevState) => {
                 return {
                     time: time,
                     currentSecondaryElement: getElement(
@@ -452,7 +453,7 @@ export default class JuxtaposeApplication extends React.Component {
             window.MediaThread.current_project,
             this.state.mediaTrack,
             this.state.textTrack
-        ).then(function(e) {
+        ).then(function() {
             jQuery(window).trigger(
                 'sequenceassignment.on_save_success', {
                     submittable: self.isBaselineWorkCompleted()
@@ -467,7 +468,7 @@ export default class JuxtaposeApplication extends React.Component {
     }
     onOutOfBoundsConfirmClick() {
         const newSpine = this.state.tmpSpineVid;
-        this.setState((prevState, props) => {
+        this.setState((prevState) => {
             return {
                 showOutOfBoundsModal: false,
                 mediaTrack: removeOutOfBoundsElements(
@@ -634,3 +635,9 @@ export default class JuxtaposeApplication extends React.Component {
         });
     }
 }
+
+JuxtaposeApplication.propTypes = {
+    primaryInstructions: React.PropTypes.string.isRequired,
+    readOnly: React.PropTypes.bool.isRequired,
+    secondaryInstructions: React.PropTypes.string.isRequired
+};

--- a/src/MediaDisplay.jsx
+++ b/src/MediaDisplay.jsx
@@ -10,7 +10,7 @@ export default class MediaDisplay extends React.Component {
         this.players = [];
         this.mediaPlayerNodes = [];
     }
-    componentWillUpdate(nextProps, nextState) {
+    componentWillUpdate(nextProps) {
         this.generatePlayers(nextProps.data);
     }
     generatePlayers(mediaTrack) {
@@ -73,3 +73,11 @@ export default class MediaDisplay extends React.Component {
         });
     }
 }
+
+MediaDisplay.propTypes = {
+    data: React.PropTypes.object.isRequired,
+    duration: React.PropTypes.number.isRequired,    
+    instructions: React.PropTypes.string.isRequired,
+    playing: React.PropTypes.bool.isRequired,
+    time: React.PropTypes.number.isRequired    
+};

--- a/src/MediaTrack.jsx
+++ b/src/MediaTrack.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Track from './Track.jsx';
 import {createCollectionWidget} from './mediathreadCollection.js';
 

--- a/src/OutOfBoundsModal.jsx
+++ b/src/OutOfBoundsModal.jsx
@@ -25,3 +25,9 @@ export default class OutOfBoundsModal extends React.Component {
         </Modal>;
     }
 }
+
+OutOfBoundsModal.propTypes = {
+    onCloseClick: React.PropTypes.func.isRequired,
+    onConfirmClick: React.PropTypes.func.isRequired,
+    showing: React.PropTypes.bool.isRequired
+};

--- a/src/PlayButton.jsx
+++ b/src/PlayButton.jsx
@@ -13,3 +13,8 @@ export default class PlayButton extends React.Component {
         </button>;
     }
 }
+
+PlayButton.propTypes = {
+    onClick: React.PropTypes.func.isRequired,
+    playing: React.PropTypes.bool.isRequired
+};

--- a/src/Playhead.jsx
+++ b/src/Playhead.jsx
@@ -32,3 +32,11 @@ export default class Playhead extends React.Component {
         </div>;
     }
 }
+
+Playhead.propTypes = {
+    currentTime: React.PropTypes.number.isRequired,
+    duration: React.PropTypes.number.isRequired,
+    onChange: React.PropTypes.func.isRequired,
+    onMouseDown: React.PropTypes.func.isRequired,
+    onMouseUp: React.PropTypes.func.isRequired
+};

--- a/src/SpineDisplay.jsx
+++ b/src/SpineDisplay.jsx
@@ -85,7 +85,7 @@ export default class SpineDisplay extends BasePlayer {
         };
         createCollectionWidget('video', true, caller);
     }
-    onClickEditSpine(e) {
+    onClickEditSpine() {
         let caller = {
             'type': 'spine',
         };

--- a/src/TextAnnotationAdder.jsx
+++ b/src/TextAnnotationAdder.jsx
@@ -41,3 +41,10 @@ export default class TextAnnotationAdder extends React.Component {
         </Modal>;
     }
 }
+
+TextAnnotationAdder.propTypes = {
+    onCloseClick: React.PropTypes.func.isRequired,
+    onSubmit: React.PropTypes.func.isRequired,
+    showing: React.PropTypes.bool.isRequired,
+    timestamp: React.PropTypes.number.isRequired
+};

--- a/src/TextDisplay.jsx
+++ b/src/TextDisplay.jsx
@@ -15,3 +15,8 @@ export default class TextDisplay extends React.Component {
         return <div className="jux-text-display-container"><div className="jux-text-display">{txt}</div></div>;
     }
 }
+
+TextDisplay.propTypes = {
+    data: React.PropTypes.object.isRequired,
+    time: React.PropTypes.number.isRequired
+};

--- a/src/TimecodeEditor.jsx
+++ b/src/TimecodeEditor.jsx
@@ -1,3 +1,5 @@
+/* global jQuery */
+
 import React from 'react';
 import _ from 'lodash';
 import {formatTimecode, parseTimecode} from './utils.js';
@@ -25,7 +27,7 @@ export default class TimecodeEditor extends React.Component {
     componentDidMount() {
         const self = this;
         jQuery(this.refs.spinner).timecodespinner({
-            change: function(e, ui) {
+            change: function(e) {
                 const seconds = parseTimecode(e.target.value);
                 if (_.isFinite(seconds)) {
                     self.props.onChange(seconds);
@@ -56,3 +58,8 @@ export default class TimecodeEditor extends React.Component {
         jQuery(this.refs.spinner).timecodespinner('destroy');
     }
 }
+
+TimecodeEditor.propTypes = {
+    min: React.PropTypes.number.isRequired,
+    timecode: React.PropTypes.number.isRequired
+};

--- a/src/TimelineRuler.jsx
+++ b/src/TimelineRuler.jsx
@@ -57,3 +57,7 @@ export default class TimelineRuler extends React.Component {
         </div>;
     }
 }
+
+TimelineRuler.propTypes = {
+    duration: React.PropTypes.number.isRequired
+};

--- a/src/Track.jsx
+++ b/src/Track.jsx
@@ -84,14 +84,13 @@ export default class Track extends React.Component {
         return null;
     }
     render() {
-        const duration = this.props.duration;
         const cssClasses = "jux-track-container jux-" + this.type;
         const displayHelpTxt =
             this.props.data.length === 0 ? 'block': 'none';
-        
+
         return <div className={cssClasses}>
                     <div className="track-icon"></div>
-	            <div className="jux-track">
+                <div className="jux-track">
                     <div className="jux-track-instructions"
                         style={{'display': displayHelpTxt}}>
                         {this.helpText}
@@ -112,10 +111,18 @@ export default class Track extends React.Component {
                         preventCollision={true}>
                         {this.generateItems(this.props.data)}
                     </ReactGridLayout>
-		    </div>
+            </div>
         </div>;
     }
     onAddWithoutPrimaryVid() {
         this.props.onAddWithoutPrimaryVid();
     }
 }
+
+Track.propTypes = {
+    data: React.PropTypes.object.isRequired,
+    duration: React.PropTypes.number.isRequired,
+    onAddWithoutPrimaryVid: React.PropTypes.func,
+    onDragStop: React.PropTypes.func.isRequired,
+    onTrackEditButtonClick: React.PropTypes.func.isRequired
+};

--- a/src/TrackElement.jsx
+++ b/src/TrackElement.jsx
@@ -90,3 +90,15 @@ export default class TrackElement extends React.Component {
         this.props.onEditButtonClick(e, this);
     }
 }
+
+TrackElement.propTypes = {
+    className: React.PropTypes.string.isRequired,
+    data: React.PropTypes.object.isRequired,
+    dragging: React.PropTypes.bool.isRequired,
+    isActive: React.PropTypes.bool.isRequired,
+    style: React.PropTypes.object,
+    onEditButtonClick: React.PropTypes.func,
+    onMouseDown: React.PropTypes.func,
+    onTouchEnd: React.PropTypes.func,
+    onTouchStart: React.PropTypes.func
+};

--- a/src/TrackElementAddColumn.jsx
+++ b/src/TrackElementAddColumn.jsx
@@ -10,3 +10,8 @@ export default class TrackElementAddColumn extends React.Component {
                ></div>;
     }
 }
+
+TrackElementAddColumn.propTypes = {
+    absoluteTimecode: React.PropTypes.number.isRequired,
+    callbackParent: React.PropTypes.func.isRequired
+};

--- a/src/TrackElementManager.jsx
+++ b/src/TrackElementManager.jsx
@@ -1,8 +1,8 @@
+/* global jQuery */
+
 import React from 'react';
 import _ from 'lodash';
-import {
-    formatTimecode, getMinutes, getSeconds, getCentiseconds
-} from './utils.js';
+import {formatTimecode} from './utils.js';
 import TimecodeEditor from './TimecodeEditor.jsx';
 import DeleteElementModal from './DeleteElementModal.jsx';
 
@@ -105,10 +105,10 @@ export default class TrackElementManager extends React.Component {
         e.preventDefault();
         this.setState({showDeleteElementModal: true});
     }
-    onDeleteCloseClick(e) {
+    onDeleteCloseClick() {
         this.setState({showDeleteElementModal: false});
     }
-    onDeleteConfirmClick(e) {
+    onDeleteConfirmClick() {
         this.props.onDeleteClick();
         this.setState({showDeleteElementModal: false});
     }
@@ -130,3 +130,10 @@ export default class TrackElementManager extends React.Component {
         this.props.onChange(this.props.activeElement, {end_time: newTime});
     }
 }
+
+TrackElementManager.propTypes = {
+    activeElement: React.PropTypes.array.isRequired,
+    onChange: React.PropTypes.func.isRequired,
+    onDeleteClick: React.PropTypes.func.isRequired,
+    onEditClick: React.PropTypes.func.isRequired
+};

--- a/src/VidItemThumb.jsx
+++ b/src/VidItemThumb.jsx
@@ -7,3 +7,7 @@ export default class VidItemThumb extends React.Component {
         }}></div>;
     }
 }
+
+VidItemThumb.propTypes = {
+    url: React.PropTypes.string.isRequired
+};

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,3 +1,5 @@
+/* global view */
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import JuxtaposeApplication from './JuxtaposeApplication.jsx';

--- a/src/mediathreadCollection.js
+++ b/src/mediathreadCollection.js
@@ -1,3 +1,5 @@
+/* global jQuery */
+
 /**
  * Functions for managing Mediathread's CollectionWidget.
  *

--- a/src/timecodeSpinner.js
+++ b/src/timecodeSpinner.js
@@ -1,3 +1,5 @@
+/* global jQuery */
+
 import {formatTimecode, parseTimecode} from './utils.js';
 
 export function defineTimecodeSpinner() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-const getYouTubeID = require('get-youtube-id');
+import getYouTubeID from 'get-youtube-id';
 
 /**
  * Returns true if the given elements collide. Only looks at
@@ -128,7 +128,7 @@ export function ellipsis(str, limit, append) {
     } else {
         return sanitized;
     }
-};
+}
 
 /**
  * extractDuration


### PR DESCRIPTION
This enables the recommended eslint configuration for React to enforce
best practices like removing unused variables:
  https://github.com/yannickcr/eslint-plugin-react#recommended

It also enforces a React feature I was unaware of called propTypes:
https://facebook.github.io/react/docs/typechecking-with-proptypes.html
Which enables runtime typechecking for component props. It prints out
console errors in development mode, and does nothing in production.