### PR TITLE
Secondary video seeking improvements - PMT #109528

### DIFF
--- a/src/AVPlayer.jsx
+++ b/src/AVPlayer.jsx
@@ -13,7 +13,10 @@ export default class AVPlayer extends BasePlayer {
     constructor(props) {
         super(props);
         this.state = {duration: null};
-        this.debouncedSeek = _.debounce(this.seekTo, 200);
+        this.debouncedSeek = _.debounce(this.seekTo, 200, {
+            leading: true,
+            trailing: false
+        });
     }
     render() {
         let url = this.props.data.source;
@@ -78,7 +81,12 @@ export default class AVPlayer extends BasePlayer {
         const newPercentage = (
             time - e.start_time + (e.annotationStartTime || 0)
         ) / this.state.duration;
-        if (newPercentage >= 0 && newPercentage <= 100) {
+
+        // The percentage may be less than 0 if the selection starts
+        // at point 0 of the video asset.
+        // A value of 1 would mean the entire length of the video, so
+        // ignore anything greater than 1.
+        if (newPercentage > -1 && newPercentage <= 1) {
             this.player.seekTo(newPercentage);
         }
     }

--- a/src/MediaDisplay.jsx
+++ b/src/MediaDisplay.jsx
@@ -13,13 +13,20 @@ export default class MediaDisplay extends React.Component {
     componentWillUpdate(nextProps, nextState) {
         this.generatePlayers(nextProps.data);
     }
+    /**
+     * Returns true if the element should be shown based on the
+     * current timeframe.
+     */
+    isElementShowing(e) {
+       return this.props.time >= e.start_time &&
+              this.props.time <= e.end_time;
+    }
     generatePlayers(mediaTrack) {
         this.players = [];
         this.mediaPlayerNodes = [];
         for (let i = 0; i < mediaTrack.length; i++) {
             let e = mediaTrack[i];
-            let showing = this.props.time >= e.start_time &&
-                          this.props.time <= e.end_time;
+            let showing = this.isElementShowing(e);
             if (e.type === 'img') {
                 this.players.push(<ImagePlayer
                            key={i}


### PR DESCRIPTION
This fixes a bug where video selections that started at asset timecode 0
weren't being cued properly, because the seekTo position just before it
starts would be a negative number.