### PR TITLE
Don't call player.pause() when AVPlayer is hidden

### DIFF
--- a/src/AVPlayer.jsx
+++ b/src/AVPlayer.jsx
@@ -60,7 +60,7 @@ export default class AVPlayer extends BasePlayer {
         this.setState({duration: duration});
     }
     onPlay() {
-        if (!this.props.playing) {
+        if (!this.props.playing && !this.props.hidden) {
             this.pause();
         }
     }


### PR DESCRIPTION
This fixes this JS error that occurs when cueing up a the sequence just
before a secondary video start playing:
> Uncaught (in promise) DOMException: The play() request was interrupted
by a call to pause().

And as a result, fixes a problem where the video stays paused in that
case.