### PR TITLE
Fix multiple vimeo players conflict - PMT #10929

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ $(JS_SENTINAL): package.json
 	rm -rf $(NODE_MODULES)
 	npm install
 	cd $(NODE_MODULES)/react-grid-layout && npm install && make build-js
+	cd $(NODE_MODULES)/react-player && npm install && npm run build:webpack
 	touch $(JS_SENTINAL)
 
 build: $(JS_SENTINAL) build/bundle.js

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-bootstrap": "~0.30.7",
     "react-dom": "~15.4.0",
     "react-grid-layout": "ccnmtl/react-grid-layout#dev",
-    "react-player": "~0.14.0",
+    "react-player": "ccnmtl/react-player#new-vimeo-api",
     "webpack": "~1.14.0",
     "whatwg-fetch": "^2.0.0"
   },


### PR DESCRIPTION
Updating from Froogaloop to vimeo's new [player.js API](https://github.com/vimeo/player.js#vimeo-player-api----)
solved this issue.

Pull request to react-player is here:
https://github.com/CookPete/react-player/pull/142

In order to actually use vimeo in the sequence tool, you need to remove
'vimeo' from the filters in collectionwidget.js in Mediathread.