### PR TITLE
Add rewind button - PMT #110065

### DIFF
--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -202,6 +202,11 @@ export default class JuxtaposeApplication extends React.Component {
                          data={this.state.textTrack} />
             <PlayButton playing={this.state.playing}
                         onClick={this.onPlayClick.bind(this)} />
+            <button className="jux-rewind"
+                    onClick={this.onRewindClick.bind(this)}>
+                <span className="glyphicon glyphicon-step-backward"
+                      title="Rewind"></span>
+            </button>
             <div className="jux-flex-horiz">
                 <div className="jux-time-display">
                     <div>
@@ -348,6 +353,18 @@ export default class JuxtaposeApplication extends React.Component {
     onPlayClick() {
         const newState = !this.state.playing;
         this.setState({playing: newState})
+    }
+    onRewindClick() {
+        this.setState({playing: false});
+        this.setState({time: 0});
+
+        var self = this;
+        // Account for the time it takes to tell the player to stop playing.
+        setTimeout(function() {
+            if (self.state.time) {
+                self.setState({time: 0});
+            }
+        }, 200);
     }
     /**
      * Remove the active track item.

--- a/src/PlayButton.jsx
+++ b/src/PlayButton.jsx
@@ -8,8 +8,10 @@ export default class PlayButton extends React.Component {
         return <button className="jux-play"
                        onClick={this.onClick.bind(this)}>
             {this.props.playing ?
-                <span className="glyphicon glyphicon-pause"></span> :
-                <span className="glyphicon glyphicon-play"></span>}
+             <span className="glyphicon glyphicon-pause"
+                   title="Pause"></span> :
+             <span className="glyphicon glyphicon-play"
+                   title="Play"></span>}
         </button>;
     }
 }


### PR DESCRIPTION
Because the player doesn't get immediately paused when we set `playing`
to `false`, the video continues to play for a short time period after
clicking the rewind button. So, it was necessary to add the
`setTimeout()` call to catch this case. This results in jumpy playhead
behavior, but it does work.

requires: https://github.com/ccnmtl/mediathread/pull/1256

![2017-02-24-133409_457x203_scrot](https://cloud.githubusercontent.com/assets/59292/23315838/f4414214-fa95-11e6-80af-9e6ca2a01c9b.png)
