### PR TITLE
Improve TimelineRuler + add tests - PMT #109445

### DIFF
--- a/__tests__/TimelineRuler-test.js
+++ b/__tests__/TimelineRuler-test.js
@@ -1,0 +1,34 @@
+/* eslint-env jest */
+
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import TimelineRuler from '../src/TimelineRuler.jsx';
+
+describe('TimelineRuler', () => {
+    it('can be initialized', () => {
+        const timelineRuler = TestUtils.renderIntoDocument(
+                <TimelineRuler duration={0} />);
+        expect(timelineRuler.props.duration).toBe(0);
+    });
+    it('calculates correct offsets for timeline ticks', () => {
+        const timelineRuler = TestUtils.renderIntoDocument(
+                <TimelineRuler duration={0} />);
+
+        expect(timelineRuler.generateTicks(0)).toEqual([[100, 0]]);
+        expect(timelineRuler.generateTicks(8889)).toEqual([
+            [0, 0],
+            [14.962312971087863, 1330],
+            [29.924625942175727, 2660],
+            [44.886938913263585, 3990],
+            [59.84925188435145, 5320],
+            [74.8115648554393, 6650],
+            [89.77387782652717, 7980],
+            [100, 8889]
+        ]);
+        expect(timelineRuler.generateTicks(37)).toEqual([
+            [0, 0],
+            [81.08108108108108, 30],
+            [100, 37]
+        ]);
+    });
+});

--- a/src/TimelineRuler.jsx
+++ b/src/TimelineRuler.jsx
@@ -31,10 +31,13 @@ export default class TimelineRuler extends React.Component {
     generateTicks(duration) {
         // Generate a tick for every 30 seconds.
         let tickOffset = 30;
-        if (duration > 300) {
+        if (duration > 300 && duration <= 900) {
             tickOffset = 60;
-        } else if (duration > 900) {
+        } else if (duration > 900 && duration <= 1800) {
             tickOffset = 120;
+        } else if (duration > 1800) {
+            // Round to nearest 10, based on the duration.
+            tickOffset = Math.round(duration * 0.15 / 10) * 10;
         }
 
         let ticks = [];
@@ -42,18 +45,33 @@ export default class TimelineRuler extends React.Component {
         // Generate ticks up until we're within 8% of the end
         for (; i < (duration - (duration * 0.08)); i += tickOffset) {
             let visualOffset = (i / duration) * 100;
-            ticks = ticks.concat(this.generateTick(visualOffset, i, false));
+            ticks.push([visualOffset, i]);
         }
 
         // Generate final tick
-        ticks = ticks.concat(this.generateTick(100, duration, true));
+        ticks.push([100, duration]);
 
         return ticks;
     }
+    generateTicksElements(duration) {
+        let self = this;
+
+        const ticks = this.generateTicks(duration);
+        let elements = [];
+        ticks.forEach(function(v, i) {
+            elements.push(
+                self.generateTick(
+                    v[0],
+                    v[1],
+                    i === (ticks.length - 1)));
+        });
+        return elements;
+    }
     render() {
+        const ticks = this.generateTicksElements(this.props.duration);
         return <div className="jux-timeline-ruler">
             <div className="jux-timeline-hline"></div>
-            {this.generateTicks(this.props.duration)}
+            {ticks}
         </div>;
     }
 }


### PR DESCRIPTION
This makes it more flexible by accounting for videos of arbitrary
length. For example, here's what it will look like for an hour-long video:
![2017-02-24-141932_1030x225_scrot](https://cloud.githubusercontent.com/assets/59292/23317435/6abc30e2-fa9c-11e6-92b5-776bc42784aa.png)
