### PR TITLE
Disable rewind button when time is 0 - PMT #110210

### DIFF
--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -24,6 +24,7 @@ import TextDisplay from './TextDisplay.jsx';
 import TimelineRuler from './TimelineRuler.jsx';
 import TrackElementManager from './TrackElementManager.jsx';
 import PlayButton from './PlayButton.jsx';
+import RewindButton from './RewindButton.jsx';
 import Playhead from './Playhead.jsx';
 import SpineDisplay from './SpineDisplay.jsx';
 import Xhr from './Xhr.js';
@@ -202,11 +203,8 @@ export default class JuxtaposeApplication extends React.Component {
                          data={this.state.textTrack} />
 
             <div className="jux-flex-horiz">
-                <button className="jux-rewind"
-                        onClick={this.onRewindClick.bind(this)}>
-                    <span className="glyphicon glyphicon-step-backward"
-                          title="Rewind"></span>
-                </button>
+                <RewindButton time={this.state.time}
+                              onClick={this.onRewindClick.bind(this)} />
                 <PlayButton playing={this.state.playing}
                             onClick={this.onPlayClick.bind(this)} />
                 <div className="jux-time-display">

--- a/src/RewindButton.jsx
+++ b/src/RewindButton.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export default class RewindButton extends React.Component {
+    onClick(event) {
+        this.props.onClick(event);
+    }
+    render() {
+        let disabled = false;
+        if (this.props.time === 0) {
+            disabled = true;
+        }
+
+        const cls = disabled ? 'jux-rewind disabled' : 'jux-rewind';
+        return <button className={cls}
+                       disabled={disabled}
+                       onClick={this.onClick.bind(this)}>
+             <span className="glyphicon glyphicon-step-backward"
+                   title="Rewind"></span>
+        </button>;
+    }
+}
+
+RewindButton.propTypes = {
+    onClick: React.PropTypes.func.isRequired,
+    time: React.PropTypes.number.isRequired
+};


### PR DESCRIPTION
This bug wasn't straightforward to solve - I'm working around it by just
disabling this button when the current time is 0, it's not useful in
that case anyways.

requires: https://github.com/ccnmtl/mediathread/pull/1290

![2017-03-08-135355_268x156_scrot](https://cloud.githubusercontent.com/assets/59292/23718819/fe2c6e50-0406-11e7-9eb7-048c29b0be24.png)
