### PR TITLE
Use upstream react-grid-layout: 0.16.6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["react", "es2015"]
-}

--- a/Makefile
+++ b/Makefile
@@ -4,20 +4,19 @@ JS_SENTINAL ?= $(NODE_MODULES)/sentinal
 $(JS_SENTINAL): package.json
 	rm -rf $(NODE_MODULES)
 	npm install
-	cd $(NODE_MODULES)/react-grid-layout && npm install && make build-js
 	touch $(JS_SENTINAL)
 
 build: $(JS_SENTINAL) build/bundle.js
-	npm run build
+	NODE_ENV="production" npm run build
 
 dev: $(JS_SENTINAL)
-	npm run dev
+	NODE_ENV="development" npm run dev
 
 eslint: $(JS_SENTINAL)
 	npm run eslint
 
 test: $(JS_SENTINAL)
-	npm run test
+	NODE_ENV="test" npm run test
 
 clean:
 	rm -rf $(NODE_MODULES)

--- a/package-lock.json
+++ b/package-lock.json
@@ -910,6 +910,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
       "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "babel-types": "^6.26.0",
@@ -1053,9 +1054,10 @@
       }
     },
     "babel-loader": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.2.tgz",
-      "integrity": "sha512-jRwlFbINAeyDStqK6Dd5YuY0k5YuzQUvlz2ZamuXrXmxav3pNqe9vfJ402+2G+OmlJSXxCOpB6Uz0INM7RQe2A==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
+      "integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
+      "dev": true,
       "requires": {
         "find-cache-dir": "^1.0.0",
         "loader-utils": "^1.0.2",
@@ -1076,6 +1078,17 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
         "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-dynamic-import-node": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.1.0.tgz",
+      "integrity": "sha512-tTfZbM9Ecwj3GK50mnPrUpinTwA4xXmDiQGCk/aBYbvl1+X8YqldK86wZ1owVJ4u3mrKbRlXMma80J18qwiaTQ==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -1144,7 +1157,8 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+      "dev": true
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
@@ -1458,10 +1472,20 @@
         "babel-runtime": "^6.26.0"
       }
     },
+    "babel-plugin-transform-react-constant-elements": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-constant-elements/-/babel-plugin-transform-react-constant-elements-6.23.0.tgz",
+      "integrity": "sha1-LxGb9NLN1F65uqrldAU8YE9hR90=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
     "babel-plugin-transform-react-display-name": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
       "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -1470,6 +1494,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
       "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+      "dev": true,
       "requires": {
         "babel-helper-builder-react-jsx": "^6.24.1",
         "babel-plugin-syntax-jsx": "^6.8.0",
@@ -1480,6 +1505,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
       "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+      "dev": true,
       "requires": {
         "babel-plugin-syntax-jsx": "^6.8.0",
         "babel-runtime": "^6.22.0"
@@ -1489,6 +1515,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
       "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+      "dev": true,
       "requires": {
         "babel-plugin-syntax-jsx": "^6.8.0",
         "babel-runtime": "^6.22.0"
@@ -1500,6 +1527,15 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "requires": {
         "regenerator-transform": "^0.10.0"
+      }
+    },
+    "babel-plugin-transform-runtime": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1528,6 +1564,44 @@
           "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
           "dev": true
         }
+      }
+    },
+    "babel-preset-env": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
+      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^2.1.2",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
       }
     },
     "babel-preset-es2015": {
@@ -1565,6 +1639,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
       "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+      "dev": true,
       "requires": {
         "babel-plugin-transform-flow-strip-types": "^6.22.0"
       }
@@ -1583,6 +1658,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
       "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+      "dev": true,
       "requires": {
         "babel-plugin-syntax-jsx": "^6.3.13",
         "babel-plugin-transform-react-display-name": "^6.23.0",
@@ -1590,6 +1666,27 @@
         "babel-plugin-transform-react-jsx-self": "^6.22.0",
         "babel-plugin-transform-react-jsx-source": "^6.22.0",
         "babel-preset-flow": "^6.23.0"
+      }
+    },
+    "babel-preset-react-app": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-3.1.1.tgz",
+      "integrity": "sha512-9fRHopNaGL5ScRZdPSoyxRaABKmkS2fx0HUJ5Yphan5G8QDFD7lETsPyY7El6b7YPT3sNrw9gfrWzl4/LsJcfA==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-dynamic-import-node": "1.1.0",
+        "babel-plugin-syntax-dynamic-import": "6.18.0",
+        "babel-plugin-transform-class-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-object-rest-spread": "6.26.0",
+        "babel-plugin-transform-react-constant-elements": "6.23.0",
+        "babel-plugin-transform-react-jsx": "6.24.1",
+        "babel-plugin-transform-react-jsx-self": "6.22.0",
+        "babel-plugin-transform-react-jsx-source": "6.22.0",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "babel-plugin-transform-runtime": "6.23.0",
+        "babel-preset-env": "1.6.1",
+        "babel-preset-react": "6.24.1"
       }
     },
     "babel-preset-stage-1": {
@@ -1952,6 +2049,16 @@
         "pako": "~1.0.5"
       }
     },
+    "browserslist": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+      "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30000792",
+        "electron-to-chromium": "^1.3.30"
+      }
+    },
     "bser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
@@ -2079,6 +2186,12 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "optional": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000844",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000844.tgz",
+      "integrity": "sha512-UpKQE7y6dLHhlv75UyBCRiun34Q+bmxyX3zS+ve9M07YG52tRafOvop9N9d5jC+sikKuG7UMweJKJNts4FVehA==",
+      "dev": true
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -3102,6 +3215,12 @@
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
       "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
+    },
+    "electron-to-chromium": {
+      "version": "1.3.47",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.47.tgz",
+      "integrity": "sha1-dk6IfKkQTQGgrI6r7n38DizhQQQ=",
+      "dev": true
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -8710,14 +8829,15 @@
       }
     },
     "react-grid-layout": {
-      "version": "github:ccnmtl/react-grid-layout#7d6bf0efd54e1aec5854bc3065d86390eff2a1c6",
-      "from": "react-grid-layout@github:ccnmtl/react-grid-layout#7d6bf0efd54e1aec5854bc3065d86390eff2a1c6",
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-0.16.6.tgz",
+      "integrity": "sha512-h2EsYgsqcESLJeevQSJsEKp8hhh+phOlXDJoMhlV2e7T3VWQL+S6iCF3iD/LK19r4oyRyOMDEir0KV+eLXrAyw==",
       "requires": {
-        "classnames": "^2.2.5",
+        "classnames": "2.x",
         "lodash.isequal": "^4.0.0",
-        "prop-types": "^15.5.8",
-        "react-draggable": "^3.0.3",
-        "react-resizable": "^1.7.4"
+        "prop-types": "15.x",
+        "react-draggable": "3.x",
+        "react-resizable": "1.x"
       }
     },
     "react-overlays": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "dev": "webpack -d --watch",
     "eslint": "eslint src/* __tests__/*"
   },
+  "babel": {
+    "presets": [
+      "react-app"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ccnmtl/juxtapose"
@@ -18,10 +23,7 @@
   "license": "GPL-3.0+",
   "dependencies": {
     "babel-core": "~6.26.0",
-    "babel-loader": "~7.1.2",
     "babel-plugin-transform-regenerator": "~6.26.0",
-    "babel-preset-es2015": "~6.24.0",
-    "babel-preset-react": "~6.24.1",
     "get-youtube-id": "~1.0.0",
     "js-cookie": "~2.2.0",
     "lodash": "~4.17.2",
@@ -30,7 +32,7 @@
     "react": "~15.6.0",
     "react-bootstrap": "~0.32.0",
     "react-dom": "~15.6.0",
-    "react-grid-layout": "ccnmtl/react-grid-layout#dev",
+    "react-grid-layout": "~0.16.6",
     "react-player": "~1.6.1",
     "webpack": "~4.8.2",
     "webpack-cli": "^2.0.9",
@@ -38,7 +40,9 @@
   },
   "devDependencies": {
     "babel-jest": "~23.0.0-alpha.0",
+    "babel-loader": "~7.1.2",
     "babel-polyfill": "~6.26.0",
+    "babel-preset-react-app": "^3.1.1",
     "eslint": "~4.19.0",
     "eslint-plugin-react": "~7.8.2",
     "exports-loader": "~0.7.0",


### PR DESCRIPTION
Now that react-grid-layout has a preventCollision option we can use it
in juxtapose. This also allowed me to modernize the makefile setup,
getting rid of the custom build-js thing which always overwrote
package.json - allowing development to be much easier.