### PR TITLE
unignore react updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,7 @@
   },
   "greenkeeper": {
     "ignore": [
-      "openlayers",
-      "react",
-      "react-dom"
+      "openlayers"
     ]
   },
   "jest": {


### PR DESCRIPTION
I remember that I couldn't update react because of some issues with our old, custom version of react-grid-layout. Now that we're using the upstream version I expect that it's compatible with react 16. I'll do some testing as greenkeeper makes PRs for this.