### PR TITLE
Remove fetch exports loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,9 +14,6 @@ var config = {
         extensions: ['.js', '.jsx']
     },
     plugins: [
-        new webpack.ProvidePlugin({
-            'fetch': 'exports-loader?self.fetch!whatwg-fetch/dist/fetch.umd'
-        }),
         new webpack.DefinePlugin({
             'process.env': {
                 // Turn 'production' env on when running `make build`


### PR DESCRIPTION
To fix the webpack build. This isn't necessary anymore.