### PR TITLE
hiding player with style prop

### DIFF
--- a/src/AVPlayer.jsx
+++ b/src/AVPlayer.jsx
@@ -43,7 +43,9 @@ export default class AVPlayer extends BasePlayer {
                    height={360}
                    url={url}
                    volume={volume}
-                   hidden={this.props.hidden}
+                   style={{
+                       display: this.props.hidden ? 'none' : 'block'
+                   }}
                    onDuration={this.onDuration.bind(this)}
                    onStart={this.onStart.bind(this)}
                    onPlay={this.onPlay.bind(this)}


### PR DESCRIPTION
* The `hidden` prop was not working properly. We instead used the `style` prop to hide the player when necessary. This fixes the bug where the secondary videos and video selections were not showing up.