### PR TITLE
Add basic pdf compatibility

### DIFF
--- a/src/Track.jsx
+++ b/src/Track.jsx
@@ -24,6 +24,29 @@ function isActive(activeElement, type, i) {
     return false;
 }
 
+// Need to use a forwardRef when using a custom component as a react
+// grid item.
+// See:
+// https://github.com/react-grid-layout/react-grid-layout/issues/1241#issuecomment-859651584
+// eslint-disable-next-line
+const TrackElementRef = React.forwardRef(
+    // eslint-disable-next-line
+    ({style, className, key, children, ...restOfProps}) => {
+    return <TrackElement
+               style={style}
+               className={className}
+               key={key}
+               {...restOfProps}>
+               {children}
+           </TrackElement>;
+});
+
+TrackElementRef.propTypes = {
+    style: PropTypes.object,
+    className: PropTypes.string,
+    children: PropTypes.array
+};
+
 
 export default class Track extends React.Component {
     constructor(props) {
@@ -99,7 +122,7 @@ export default class Track extends React.Component {
             const xPos = percentToTrackCoords(percent);
             const active = isActive(me.props.activeElement, me.type, i);
 
-            const item = <TrackElement
+            const item = <TrackElementRef
                              onEditButtonClick={me.onEditButtonClick.bind(me)}
                              isActive={active}
                              key={i}
@@ -109,7 +132,9 @@ export default class Track extends React.Component {
                                  y: 0,
                                  w: width,
                                  h: 49
-                             }} />;
+                             }}
+                         />;
+
             items.push(item);
         });
         return items;

--- a/src/TrackElement.jsx
+++ b/src/TrackElement.jsx
@@ -9,7 +9,7 @@ export default class TrackElement extends React.Component {
         super(props);
         this.state = {
             vimeoThumbnailUrl: null
-        }
+        };
     }
     vimeoThumbnailListener(e) {
         const json = e.target.responseText;

--- a/src/utils.js
+++ b/src/utils.js
@@ -285,6 +285,12 @@ function extractSource(o) {
             height: o.image.height
         };
     }
+    if (o.pdf && o.pdf.url) {
+        return {
+            url: o.pdf.url
+        };
+    }
+
     return null;
 }
 
@@ -327,8 +333,14 @@ export function parseAsset(json, assetId, annotationId) {
     const assetCtx = json.assets[assetId];
     const source = extractSource(assetCtx.sources);
     const annotation = extractRange(assetCtx, annotationId);
-    const type = assetCtx.primary_type === 'image' ? 'img' : 'vid';
-    const duration = type === 'img' ? 30 : annotation.duration;
+
+    let type = assetCtx.primary_type === 'image' ? 'img' : 'vid';
+    if (assetCtx.primary_type === 'pdf') {
+        type = 'pdf';
+    }
+
+    const duration = (type === 'img' || type === 'pdf') ?
+          30 : annotation.duration;
 
     return {
         url: source.url,
@@ -347,7 +359,11 @@ export function parseAsset(json, assetId, annotationId) {
  *
  */
 export function parseAnnotation(annotation) {
-    const type = annotation.asset.media_type === 'image' ? 'img' : 'vid';
+    let type = annotation.asset.media_type === 'image' ? 'img' : 'vid';
+    if (annotation.asset.media_type === 'pdf') {
+        type = 'pdf';
+    }
+
     const duration = extractDuration(annotation);
 
     let url = annotation.asset.primary_source.url;


### PR DESCRIPTION
We'll need to actually add in the PDF viewer here too, but this makes
the code not crash when attempting to work with PDF assets.

Also, fixes a react-grid-layout bug where the track items aren't draggable.