### PR TITLE
TrackElement: fix forwardRef warning

### DIFF
--- a/src/Track.jsx
+++ b/src/Track.jsx
@@ -31,11 +31,12 @@ function isActive(activeElement, type, i) {
 // eslint-disable-next-line
 const TrackElementRef = React.forwardRef(
     // eslint-disable-next-line
-    ({style, className, key, children, ...restOfProps}) => {
+    ({style, className, key, children, ...restOfProps}, ref) => {
     return <TrackElement
                style={style}
                className={className}
                key={key}
+               ref={ref}
                {...restOfProps}>
                {children}
            </TrackElement>;


### PR DESCRIPTION
Fix this warning by defining the ref parameter when using forwardRef:
> Warning: forwardRef render functions accept exactly two
> parameters: props and ref. Did you forget to use the ref
> parameter?