### PR TITLE
Remove 'min' prop from TimecodeEditor

### DIFF
--- a/src/TimecodeEditor.jsx
+++ b/src/TimecodeEditor.jsx
@@ -13,9 +13,10 @@ import {formatTimecode, parseTimecode} from './utils.js';
 export default class TimecodeEditor extends React.Component {
     render() {
         return <div className="jux-timecode-editor">
-    <input ref={(c) => this._spinner = c} min={this.props.min} required
-           defaultValue={formatTimecode(this.props.timecode)} />
-        </div>;
+                   <input ref={(c) => this._spinner = c}
+                          required
+                          defaultValue={formatTimecode(this.props.timecode)} />
+               </div>;
     }
     componentDidUpdate(props) {
         // Because this is an uncontrolled input, we need to manually
@@ -61,7 +62,6 @@ export default class TimecodeEditor extends React.Component {
 }
 
 TimecodeEditor.propTypes = {
-    min: PropTypes.number.isRequired,
     onChange: PropTypes.func.isRequired,
     timecode: PropTypes.number.isRequired
 };

--- a/src/TrackElementManager.jsx
+++ b/src/TrackElementManager.jsx
@@ -56,7 +56,6 @@ export default class TrackElementManager extends React.Component {
                     Start <br />{formatTimecode(activeElement.start_time)}
                 </label><br />
                 <TimecodeEditor
-                    min={0}
                     timecode={activeElement.start_time}
                     onChange={this.onStartTimeChange.bind(this)}
                 />
@@ -69,7 +68,6 @@ export default class TrackElementManager extends React.Component {
                     Duration &nbsp;{formatTimecode(duration)}
                 </label><br />
                 <TimecodeEditor
-                    min={100}
                     timecode={activeElement.end_time - activeElement.start_time}
                     onChange={this.onDurationChange.bind(this)}
                 />


### PR DESCRIPTION
This isn't an `<input type="number">`, so the `min` attribute doesn't make sense, and isn't really doing anything. This is actually a text input, using jQuery UI Spinner: https://jqueryui.com/spinner/