### PR TITLE
Add max prop to TimecodeEditor

### DIFF
--- a/src/JuxtaposeApplication.jsx
+++ b/src/JuxtaposeApplication.jsx
@@ -233,7 +233,8 @@ export default class JuxtaposeApplication extends React.Component {
                 activeElement={activeElement}
                 onChange={this.onTrackElementUpdate.bind(this)}
                 onEditClick={this.onTrackMediaElementEdit.bind(this)}
-                onDeleteClick={this.onTrackElementRemove.bind(this)} />
+                onDeleteClick={this.onTrackElementRemove.bind(this)}
+                duration={this.state.duration} />
             <OutOfBoundsModal
                 showing={this.state.showOutOfBoundsModal}
                 onCloseClick={this.onOutOfBoundsCloseClick.bind(this)}

--- a/src/TimecodeEditor.jsx
+++ b/src/TimecodeEditor.jsx
@@ -12,10 +12,18 @@ import {formatTimecode, parseTimecode} from './utils.js';
  */
 export default class TimecodeEditor extends React.Component {
     render() {
+        let formattedMax = '99:00:00';
+        if (this.props.max) {
+            formattedMax = formatTimecode(this.props.max);
+        }
+
         return <div className="jux-timecode-editor">
-    <input ref={(c) => this._spinner = c} min={this.props.min} required
-           defaultValue={formatTimecode(this.props.timecode)} />
-        </div>;
+                   <input ref={(c) => this._spinner = c}
+                          min={formatTimecode(this.props.min)}
+                          max={formattedMax}
+                          required
+                          defaultValue={formatTimecode(this.props.timecode)} />
+               </div>;
     }
     componentDidUpdate(props) {
         // Because this is an uncontrolled input, we need to manually
@@ -62,6 +70,7 @@ export default class TimecodeEditor extends React.Component {
 
 TimecodeEditor.propTypes = {
     min: PropTypes.number.isRequired,
+    max: PropTypes.number,
     onChange: PropTypes.func.isRequired,
     timecode: PropTypes.number.isRequired
 };

--- a/src/TrackElementManager.jsx
+++ b/src/TrackElementManager.jsx
@@ -57,6 +57,7 @@ export default class TrackElementManager extends React.Component {
                 </label><br />
                 <TimecodeEditor
                     min={0}
+                    max={this.props.duration}
                     timecode={activeElement.start_time}
                     onChange={this.onStartTimeChange.bind(this)}
                 />
@@ -69,7 +70,8 @@ export default class TrackElementManager extends React.Component {
                     Duration &nbsp;{formatTimecode(duration)}
                 </label><br />
                 <TimecodeEditor
-                    min={100}
+                    min={1}
+                    max={this.props.duration}
                     timecode={activeElement.end_time - activeElement.start_time}
                     onChange={this.onDurationChange.bind(this)}
                 />
@@ -178,5 +180,9 @@ TrackElementManager.propTypes = {
     activeElement: PropTypes.object,
     onChange: PropTypes.func.isRequired,
     onDeleteClick: PropTypes.func.isRequired,
-    onEditClick: PropTypes.func.isRequired
+    onEditClick: PropTypes.func.isRequired,
+
+    // Don't mark this as required as the video duration may still be
+    // loading.
+    duration: PropTypes.number
 };


### PR DESCRIPTION
Using video's duration as `max`, when it's available.

It has to be formatted in a special way as this input uses a modified version of the jQuery UI Spinner:

* https://jqueryui.com/spinner/
* https://api.jqueryui.com/spinner/